### PR TITLE
feat(schema): add Schema attributes and enhance DocBlock array type parsing

### DIFF
--- a/src/Attributes/Schema.php
+++ b/src/Attributes/Schema.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Attributes;
+
+use Attribute;
+use PhpMcp\Server\Attributes\Schema\ArrayItems;
+use PhpMcp\Server\Attributes\Schema\Property;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Schema
+{
+    /** @var Property[] */
+    protected array $properties = [];
+    
+    /**
+     * @param string|null $format String format (email, date-time, uri, etc.)
+     * @param int|null $minLength Minimum string length
+     * @param int|null $maxLength Maximum string length
+     * @param string|null $pattern Regular expression pattern
+     * @param int|float|null $minimum Minimum numeric value
+     * @param int|float|null $maximum Maximum numeric value
+     * @param bool|null $exclusiveMinimum Whether minimum is exclusive
+     * @param bool|null $exclusiveMaximum Whether maximum is exclusive
+     * @param int|float|null $multipleOf Value must be multiple of this number
+     * @param ArrayItems|null $items Schema for array items
+     * @param int|null $minItems Minimum array items
+     * @param int|null $maxItems Maximum array items
+     * @param bool|null $uniqueItems Whether array items must be unique
+     * @param Property[] $properties Properties for object validation
+     * @param string[]|null $required Required properties for objects
+     * @param bool|Schema|null $additionalProperties Whether additional properties are allowed
+     * @param mixed|null $enum List of allowed values
+     * @param mixed|null $default Default value
+     */
+    public function __construct(
+        public ?string $format = null,
+        public ?int $minLength = null,
+        public ?int $maxLength = null,
+        public ?string $pattern = null,
+        public int|float|null $minimum = null,
+        public int|float|null $maximum = null,
+        public ?bool $exclusiveMinimum = null,
+        public ?bool $exclusiveMaximum = null,
+        public int|float|null $multipleOf = null,
+        public ?ArrayItems $items = null,
+        public ?int $minItems = null,
+        public ?int $maxItems = null,
+        public ?bool $uniqueItems = null,
+        array $properties = [],
+        public ?array $required = null,
+        public bool|Schema|null $additionalProperties = null,
+        public mixed $enum = null,
+        public mixed $default = null,
+    ) {
+        $this->properties = $properties;
+    }
+
+    /**
+     * Convert to JSON Schema array
+     */
+    public function toArray(): array
+    {
+        $schema = [];
+        
+        // String constraints
+        if ($this->format !== null) $schema['format'] = $this->format;
+        if ($this->minLength !== null) $schema['minLength'] = $this->minLength;
+        if ($this->maxLength !== null) $schema['maxLength'] = $this->maxLength;
+        if ($this->pattern !== null) $schema['pattern'] = $this->pattern;
+        
+        // Numeric constraints
+        if ($this->minimum !== null) $schema['minimum'] = $this->minimum;
+        if ($this->maximum !== null) $schema['maximum'] = $this->maximum;
+        if ($this->exclusiveMinimum !== null) $schema['exclusiveMinimum'] = $this->exclusiveMinimum;
+        if ($this->exclusiveMaximum !== null) $schema['exclusiveMaximum'] = $this->exclusiveMaximum;
+        if ($this->multipleOf !== null) $schema['multipleOf'] = $this->multipleOf;
+        
+        // Array constraints
+        if ($this->items !== null) $schema['items'] = $this->items->toArray();
+        if ($this->minItems !== null) $schema['minItems'] = $this->minItems;
+        if ($this->maxItems !== null) $schema['maxItems'] = $this->maxItems;
+        if ($this->uniqueItems !== null) $schema['uniqueItems'] = $this->uniqueItems;
+        
+        // Object constraints
+        if (!empty($this->properties)) {
+            $props = [];
+            foreach ($this->properties as $property) {
+                $props[$property->name] = $property->toArray();
+            }
+            $schema['properties'] = $props;
+        }
+        
+        if ($this->required !== null) $schema['required'] = $this->required;
+        
+        if ($this->additionalProperties !== null) {
+            if ($this->additionalProperties instanceof self) {
+                $schema['additionalProperties'] = $this->additionalProperties->toArray();
+            } else {
+                $schema['additionalProperties'] = $this->additionalProperties;
+            }
+        }
+        
+        // General constraints
+        if ($this->enum !== null) $schema['enum'] = $this->enum;
+        if ($this->default !== null) $schema['default'] = $this->default;
+        
+        return $schema;
+    }
+} 

--- a/src/Attributes/Schema/ArrayItems.php
+++ b/src/Attributes/Schema/ArrayItems.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Attributes\Schema;
+
+use PhpMcp\Server\Attributes\Schema;
+
+/**
+ * Array item schema - extends Schema to inherit all schema properties
+ */
+class ArrayItems extends Schema
+{
+    /**
+     * Creates a schema definition for array items
+     */
+    public function __construct(
+        ?string $format = null,
+        ?int $minLength = null,
+        ?int $maxLength = null,
+        ?string $pattern = null,
+        int|float|null $minimum = null,
+        int|float|null $maximum = null,
+        ?bool $exclusiveMinimum = null,
+        ?bool $exclusiveMaximum = null,
+        int|float|null $multipleOf = null,
+        ?ArrayItems $items = null,
+        ?int $minItems = null,
+        ?int $maxItems = null,
+        ?bool $uniqueItems = null,
+        array $properties = [],
+        ?array $required = null,
+        bool|Schema|null $additionalProperties = null,
+        mixed $enum = null,
+        mixed $default = null,
+    ) {
+        parent::__construct(
+            format: $format,
+            minLength: $minLength,
+            maxLength: $maxLength,
+            pattern: $pattern,
+            minimum: $minimum,
+            maximum: $maximum,
+            exclusiveMinimum: $exclusiveMinimum,
+            exclusiveMaximum: $exclusiveMaximum,
+            multipleOf: $multipleOf,
+            items: $items,
+            minItems: $minItems,
+            maxItems: $maxItems,
+            uniqueItems: $uniqueItems,
+            properties: $properties,
+            required: $required,
+            additionalProperties: $additionalProperties,
+            enum: $enum,
+            default: $default,
+        );
+    }
+} 

--- a/src/Attributes/Schema/Format.php
+++ b/src/Attributes/Schema/Format.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Attributes\Schema;
+
+/**
+ * Common string formats supported by JSON Schema
+ */
+class Format
+{
+    // String formats
+    public const DATE = 'date';
+    public const TIME = 'time';
+    public const DATE_TIME = 'date-time';
+    public const DURATION = 'duration';
+    public const EMAIL = 'email';
+    public const IDN_EMAIL = 'idn-email';
+    public const HOSTNAME = 'hostname';
+    public const IDN_HOSTNAME = 'idn-hostname';
+    public const IPV4 = 'ipv4';
+    public const IPV6 = 'ipv6';
+    public const URI = 'uri';
+    public const URI_REFERENCE = 'uri-reference';
+    public const IRI = 'iri';
+    public const IRI_REFERENCE = 'iri-reference';
+    public const URI_TEMPLATE = 'uri-template';
+    public const JSON_POINTER = 'json-pointer';
+    public const RELATIVE_JSON_POINTER = 'relative-json-pointer';
+    public const REGEX = 'regex';
+    public const UUID = 'uuid';
+} 

--- a/src/Attributes/Schema/Property.php
+++ b/src/Attributes/Schema/Property.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Attributes\Schema;
+
+use PhpMcp\Server\Attributes\Schema;
+
+/**
+ * Property definition for object schemas
+ */
+class Property extends Schema
+{
+    /**
+     * @param string $name Property name
+     */
+    public function __construct(
+        public string $name,
+        ?string $format = null,
+        ?int $minLength = null,
+        ?int $maxLength = null,
+        ?string $pattern = null,
+        int|float|null $minimum = null,
+        int|float|null $maximum = null,
+        ?bool $exclusiveMinimum = null,
+        ?bool $exclusiveMaximum = null,
+        int|float|null $multipleOf = null,
+        ?ArrayItems $items = null,
+        ?int $minItems = null,
+        ?int $maxItems = null,
+        ?bool $uniqueItems = null,
+        array $properties = [],
+        ?array $required = null,
+        bool|Schema|null $additionalProperties = null,
+        mixed $enum = null,
+        mixed $default = null,
+    ) {
+        parent::__construct(
+            format: $format,
+            minLength: $minLength,
+            maxLength: $maxLength,
+            pattern: $pattern,
+            minimum: $minimum,
+            maximum: $maximum,
+            exclusiveMinimum: $exclusiveMinimum,
+            exclusiveMaximum: $exclusiveMaximum,
+            multipleOf: $multipleOf,
+            items: $items,
+            minItems: $minItems,
+            maxItems: $maxItems,
+            uniqueItems: $uniqueItems,
+            properties: $properties,
+            required: $required,
+            additionalProperties: $additionalProperties,
+            enum: $enum,
+            default: $default,
+        );
+    }
+} 

--- a/tests/Mocks/SupportStubs/DocBlockArrayTestStub.php
+++ b/tests/Mocks/SupportStubs/DocBlockArrayTestStub.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace PhpMcp\Server\Tests\Mocks\SupportStubs;
+
+/**
+ * Test stub for DocBlock array type parsing
+ */
+class DocBlockArrayTestStub
+{
+    /**
+     * Method with simple array[] syntax
+     * 
+     * @param string[] $strings Array of strings using [] syntax
+     * @param int[] $integers Array of integers using [] syntax
+     * @param bool[] $booleans Array of booleans using [] syntax
+     * @param float[] $floats Array of floats using [] syntax
+     * @param object[] $objects Array of objects using [] syntax
+     * @param \DateTime[] $dateTimeInstances Array of DateTime objects
+     */
+    public function simpleArraySyntax(
+        array $strings,
+        array $integers,
+        array $booleans, 
+        array $floats,
+        array $objects,
+        array $dateTimeInstances
+    ): void {
+    }
+
+    /**
+     * Method with array<T> generic syntax
+     * 
+     * @param array<string> $strings Array of strings using generic syntax
+     * @param array<int> $integers Array of integers using generic syntax
+     * @param array<bool> $booleans Array of booleans using generic syntax
+     * @param array<float> $floats Array of floats using generic syntax
+     * @param array<object> $objects Array of objects using generic syntax
+     * @param array<\DateTime> $dateTimeInstances Array of DateTime objects using generic syntax
+     */
+    public function genericArraySyntax(
+        array $strings,
+        array $integers, 
+        array $booleans,
+        array $floats,
+        array $objects,
+        array $dateTimeInstances
+    ): void {
+    }
+
+    /**
+     * Method with nested array syntax
+     * 
+     * @param array<array<string>> $nestedStringArrays Array of arrays of strings
+     * @param array<array<int>> $nestedIntArrays Array of arrays of integers
+     * @param string[][] $doubleStringArrays Array of arrays of strings using double []
+     * @param int[][] $doubleIntArrays Array of arrays of integers using double []
+     */
+    public function nestedArraySyntax(
+        array $nestedStringArrays,
+        array $nestedIntArrays,
+        array $doubleStringArrays,
+        array $doubleIntArrays
+    ): void {
+    }
+
+    /**
+     * Method with object-like array syntax
+     * 
+     * @param array{name: string, age: int} $person Simple object array with name and age
+     * @param array{id: int, title: string, tags: string[]} $article Article with array of tags
+     * @param array{user: array{id: int, name: string}, items: array<int>} $order Order with nested user object and array of item IDs
+     */
+    public function objectArraySyntax(
+        array $person,
+        array $article,
+        array $order
+    ): void {
+    }
+} 

--- a/tests/Mocks/SupportStubs/SchemaAttributeTestStub.php
+++ b/tests/Mocks/SupportStubs/SchemaAttributeTestStub.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace PhpMcp\Server\Tests\Mocks\SupportStubs;
+
+use PhpMcp\Server\Attributes\Schema;
+use PhpMcp\Server\Attributes\Schema\ArrayItems;
+use PhpMcp\Server\Attributes\Schema\Format;
+use PhpMcp\Server\Attributes\Schema\Property;
+
+class SchemaAttributeTestStub
+{
+    /**
+     * Method with string Schema attribute constraints
+     *
+     * @param string $email Email address with format constraint
+     * @param string $password Password with length and pattern constraints
+     * @param string $code Simple string with no constraints
+     */
+    public function stringConstraints(
+        #[Schema(format: Format::EMAIL)] string $email,
+        #[Schema(minLength: 8, pattern: '^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$')] string $password,
+        string $code
+    ): void {
+    }
+
+    /**
+     * Method with numeric Schema attribute constraints
+     *
+     * @param int $age Age with range constraints
+     * @param float $rating Rating with min/max
+     * @param int $count Count with multipleOf constraint
+     */
+    public function numericConstraints(
+        #[Schema(minimum: 18, maximum: 120)] 
+        int $age,
+
+        #[Schema(minimum: 0, maximum: 5, exclusiveMaximum: true)]
+        float $rating,
+
+        #[Schema(minimum: 0, multipleOf: 10)] 
+        int $count
+    ): void {
+    }
+
+    /**
+     * Method with array Schema attribute constraints
+     *
+     * @param string[] $tags Tags with uniqueItems
+     * @param int[] $scores Scores with item constraints
+     * @param array $mixed Mixed array with no constraints
+     */
+    public function arrayConstraints(
+        #[Schema(minItems: 1, uniqueItems: true)] 
+        array $tags,
+        #[Schema(minItems: 1, maxItems: 5, items: new ArrayItems(minimum: 0, maximum: 100))] 
+        array $scores,
+        array $mixed
+    ): void {
+    }
+
+    /**
+     * Method with object Schema attribute constraints
+     *
+     * @param array $user User object with properties
+     * @param array $config Config with additional properties
+     */
+    public function objectConstraints(
+        #[Schema(
+            properties: [
+                new Property('name', minLength: 2),
+                new Property('email', format: Format::EMAIL),
+                new Property('age', minimum: 18)
+            ],
+            required: ['name', 'email']
+        )] 
+        array $user,
+
+        #[Schema(additionalProperties: true)] 
+        array $config
+    ): void {
+    }
+
+    /**
+     * Method with nested Schema attribute constraints
+     *
+     * @param array $order Order with nested properties
+     */
+    public function nestedConstraints(
+        #[Schema(
+            properties: [
+                new Property('customer', 
+                    properties: [
+                        new Property('id', pattern: '^CUS-[0-9]{6}$'),
+                        new Property('name', minLength: 2)
+                    ],
+                    required: ['id']
+                ),
+                new Property('items', 
+                    minItems: 1,
+                    items: new ArrayItems(
+                        properties: [
+                            new Property('product_id', pattern: '^PRD-[0-9]{4}$'),
+                            new Property('quantity', minimum: 1)
+                        ],
+                        required: ['product_id', 'quantity']
+                    )
+                )
+            ],
+            required: ['customer', 'items']
+        )] array $order
+    ): void {
+    }
+
+    /**
+     * Method to test precedence between PHP type, DocBlock, and Schema attributes
+     *
+     * @param integer $numericString DocBlock says this is an integer despite string type hint
+     * @param string $stringWithFormat DocBlock type matches PHP but Schema adds format
+     * @param array<string> $arrayWithItems DocBlock specifies string[] but Schema overrides with number constraints
+     */
+    public function typePrecedenceTest(
+        string $numericString,  // PHP says string
+
+        #[Schema(format: Format::EMAIL)] 
+        string $stringWithFormat,  // PHP + Schema
+
+        #[Schema(items: new ArrayItems(minimum: 1, maximum: 100))] 
+        array $arrayWithItems  // Schema overrides DocBlock
+    ): void {
+    }
+} 

--- a/tests/Unit/Support/SchemaGeneratorTest.php
+++ b/tests/Unit/Support/SchemaGeneratorTest.php
@@ -8,6 +8,8 @@ use phpDocumentor\Reflection\DocBlockFactory;
 use PhpMcp\Server\Support\DocBlockParser;
 use PhpMcp\Server\Support\SchemaGenerator;
 use PhpMcp\Server\Tests\Mocks\SupportStubs\SchemaGeneratorTestStub;
+use PhpMcp\Server\Tests\Mocks\SupportStubs\SchemaAttributeTestStub;
+use PhpMcp\Server\Tests\Mocks\SupportStubs\DocBlockArrayTestStub;
 use ReflectionMethod;
 
 // --- Setup ---
@@ -208,4 +210,266 @@ test('generates schema using docblock type overriding php type hint', function (
     // Docblock type (@param string) overrides PHP type hint (int)
     expect($schema['properties']['p1'])->toEqual(['type' => 'string', 'description' => 'Docblock overrides int']);
     expect($schema['required'])->toEqualCanonicalizing(['p1']);
+});
+
+test('generates schema with string format constraints from Schema attribute', function () {
+    $method = new ReflectionMethod(SchemaAttributeTestStub::class, 'stringConstraints');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    expect($schema['properties']['email'])->toHaveKey('format')
+        ->and($schema['properties']['email']['format'])->toBe('email');
+    
+    expect($schema['properties']['password'])->toHaveKey('minLength')
+        ->and($schema['properties']['password']['minLength'])->toBe(8);
+    expect($schema['properties']['password'])->toHaveKey('pattern')
+        ->and($schema['properties']['password']['pattern'])->toBe('^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$');
+    
+    // Regular parameter should not have format constraints
+    expect($schema['properties']['code'])->not->toHaveKey('format');
+    expect($schema['properties']['code'])->not->toHaveKey('minLength');
+});
+
+test('generates schema with numeric constraints from Schema attribute', function () {
+    $method = new ReflectionMethod(SchemaAttributeTestStub::class, 'numericConstraints');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    expect($schema['properties']['age'])->toHaveKey('minimum')
+        ->and($schema['properties']['age']['minimum'])->toBe(18);
+    expect($schema['properties']['age'])->toHaveKey('maximum')
+        ->and($schema['properties']['age']['maximum'])->toBe(120);
+
+    expect($schema['properties']['rating'])->toHaveKey('minimum')
+        ->and($schema['properties']['rating']['minimum'])->toBe(0);
+    expect($schema['properties']['rating'])->toHaveKey('maximum')
+        ->and($schema['properties']['rating']['maximum'])->toBe(5);
+    expect($schema['properties']['rating'])->toHaveKey('exclusiveMaximum')
+        ->and($schema['properties']['rating']['exclusiveMaximum'])->toBeTrue();
+
+    expect($schema['properties']['count'])->toHaveKey('multipleOf')
+        ->and($schema['properties']['count']['multipleOf'])->toBe(10);
+});
+
+test('generates schema with array constraints from Schema attribute', function () {
+    $method = new ReflectionMethod(SchemaAttributeTestStub::class, 'arrayConstraints');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    expect($schema['properties']['tags'])->toHaveKey('uniqueItems')
+        ->and($schema['properties']['tags']['uniqueItems'])->toBeTrue();
+    expect($schema['properties']['tags'])->toHaveKey('minItems')
+        ->and($schema['properties']['tags']['minItems'])->toBe(1);
+
+    expect($schema['properties']['scores'])->toHaveKey('minItems')
+        ->and($schema['properties']['scores']['minItems'])->toBe(1);
+    expect($schema['properties']['scores'])->toHaveKey('maxItems')
+        ->and($schema['properties']['scores']['maxItems'])->toBe(5);
+    expect($schema['properties']['scores'])->toHaveKey('items')
+        ->and($schema['properties']['scores']['items'])->toHaveKey('minimum')
+        ->and($schema['properties']['scores']['items']['minimum'])->toBe(0);
+    expect($schema['properties']['scores']['items'])->toHaveKey('maximum')
+        ->and($schema['properties']['scores']['items']['maximum'])->toBe(100);
+
+    // Regular array should not have constraints
+    expect($schema['properties']['mixed'])->not->toHaveKey('minItems');
+    expect($schema['properties']['mixed'])->not->toHaveKey('uniqueItems');
+});
+
+test('generates schema with object constraints from Schema attribute', function () {
+    $method = new ReflectionMethod(SchemaAttributeTestStub::class, 'objectConstraints');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    // Check properties
+    expect($schema['properties']['user'])->toHaveKey('properties');
+    $properties = $schema['properties']['user']['properties'];
+
+    expect($properties)->toHaveKeys(['name', 'email', 'age']);
+    expect($properties['name'])->toHaveKey('minLength')
+        ->and($properties['name']['minLength'])->toBe(2);
+    expect($properties['email'])->toHaveKey('format')
+        ->and($properties['email']['format'])->toBe('email');
+    expect($properties['age'])->toHaveKey('minimum')
+        ->and($properties['age']['minimum'])->toBe(18);
+
+    // Check required
+    expect($schema['properties']['user'])->toHaveKey('required')
+        ->and($schema['properties']['user']['required'])->toContain('name')
+        ->and($schema['properties']['user']['required'])->toContain('email');
+
+    // Check additionalProperties
+    expect($schema['properties']['config'])->toHaveKey('additionalProperties')
+        ->and($schema['properties']['config']['additionalProperties'])->toBeTrue();
+});
+
+test('generates schema with nested constraints from Schema attribute', function () {
+    $method = new ReflectionMethod(SchemaAttributeTestStub::class, 'nestedConstraints');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    // Check top level properties exist
+    expect($schema['properties']['order'])->toHaveKey('properties');
+    expect($schema['properties']['order']['properties'])->toHaveKeys(['customer', 'items']);
+    
+    // Check customer properties
+    $customer = $schema['properties']['order']['properties']['customer'];
+    expect($customer)->toHaveKey('properties');
+    expect($customer['properties'])->toHaveKeys(['id', 'name']);
+    expect($customer['properties']['id'])->toHaveKey('pattern');
+    expect($customer['required'])->toContain('id');
+    
+    // Check items properties
+    $items = $schema['properties']['order']['properties']['items'];
+    expect($items)->toHaveKey('minItems')
+        ->and($items['minItems'])->toBe(1);
+    expect($items)->toHaveKey('items');
+    
+    // Check items schema
+    $itemsSchema = $items['items'];
+    expect($itemsSchema)->toHaveKey('properties');
+    expect($itemsSchema['properties'])->toHaveKeys(['product_id', 'quantity']);
+    expect($itemsSchema['required'])->toContain('product_id')
+        ->and($itemsSchema['required'])->toContain('quantity');
+    expect($itemsSchema['properties']['product_id'])->toHaveKey('pattern');
+    expect($itemsSchema['properties']['quantity'])->toHaveKey('minimum')
+        ->and($itemsSchema['properties']['quantity']['minimum'])->toBe(1);
+});
+
+test('respects precedence order between PHP type, DocBlock, and Schema attributes', function () {
+    $method = new ReflectionMethod(SchemaAttributeTestStub::class, 'typePrecedenceTest');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    // Test Case 1: DocBlock type (integer) should override PHP type (string)
+    // but keep string characteristics (not have integer constraints)
+    expect($schema['properties']['numericString'])->toHaveKey('type')
+        ->and($schema['properties']['numericString']['type'])->toBe('integer')
+        ->and($schema['properties']['numericString'])->not->toHaveKey('format');  // No string format since type is now integer
+
+    // Test Case 2: Schema format should be applied even when type is from PHP/DocBlock
+    expect($schema['properties']['stringWithFormat'])->toHaveKey('type')
+        ->and($schema['properties']['stringWithFormat']['type'])->toBe('string')
+        ->and($schema['properties']['stringWithFormat'])->toHaveKey('format')
+        ->and($schema['properties']['stringWithFormat']['format'])->toBe('email');
+
+    // Test Case 3: Schema items constraints should override DocBlock array<string> hint
+    expect($schema['properties']['arrayWithItems'])->toHaveKey('type')
+        ->and($schema['properties']['arrayWithItems']['type'])->toBe('array')
+        ->and($schema['properties']['arrayWithItems'])->toHaveKey('items')
+        ->and($schema['properties']['arrayWithItems']['items'])->toHaveKey('minimum')
+        ->and($schema['properties']['arrayWithItems']['items']['minimum'])->toBe(1)
+        ->and($schema['properties']['arrayWithItems']['items'])->toHaveKey('maximum')
+        ->and($schema['properties']['arrayWithItems']['items']['maximum'])->toBe(100);
+});
+
+test('parses simple array[] syntax correctly', function () {
+    $method = new ReflectionMethod(DocBlockArrayTestStub::class, 'simpleArraySyntax');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    // Check each parameter type is correctly inferred
+    expect($schema['properties']['strings'])->toHaveKey('items')
+        ->and($schema['properties']['strings']['items']['type'])->toBe('string');
+        
+    expect($schema['properties']['integers'])->toHaveKey('items')
+        ->and($schema['properties']['integers']['items']['type'])->toBe('integer');
+        
+    expect($schema['properties']['booleans'])->toHaveKey('items')
+        ->and($schema['properties']['booleans']['items']['type'])->toBe('boolean');
+        
+    expect($schema['properties']['floats'])->toHaveKey('items')
+        ->and($schema['properties']['floats']['items']['type'])->toBe('number');
+        
+    expect($schema['properties']['objects'])->toHaveKey('items')
+        ->and($schema['properties']['objects']['items']['type'])->toBe('object');
+        
+    expect($schema['properties']['dateTimeInstances'])->toHaveKey('items')
+        ->and($schema['properties']['dateTimeInstances']['items']['type'])->toBe('object');
+});
+
+test('parses array<T> generic syntax correctly', function () {
+    $method = new ReflectionMethod(DocBlockArrayTestStub::class, 'genericArraySyntax');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    // Check each parameter type is correctly inferred
+    expect($schema['properties']['strings'])->toHaveKey('items')
+        ->and($schema['properties']['strings']['items']['type'])->toBe('string');
+        
+    expect($schema['properties']['integers'])->toHaveKey('items')
+        ->and($schema['properties']['integers']['items']['type'])->toBe('integer');
+        
+    expect($schema['properties']['booleans'])->toHaveKey('items')
+        ->and($schema['properties']['booleans']['items']['type'])->toBe('boolean');
+        
+    expect($schema['properties']['floats'])->toHaveKey('items')
+        ->and($schema['properties']['floats']['items']['type'])->toBe('number');
+        
+    expect($schema['properties']['objects'])->toHaveKey('items')
+        ->and($schema['properties']['objects']['items']['type'])->toBe('object');
+        
+    expect($schema['properties']['dateTimeInstances'])->toHaveKey('items')
+        ->and($schema['properties']['dateTimeInstances']['items']['type'])->toBe('object');
+});
+
+test('parses nested array syntax correctly', function () {
+    $method = new ReflectionMethod(DocBlockArrayTestStub::class, 'nestedArraySyntax');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    // Check for nested arrays with array<array<string>> syntax
+    expect($schema['properties']['nestedStringArrays'])->toHaveKey('items')
+        ->and($schema['properties']['nestedStringArrays']['items'])->toHaveKey('type')
+        ->and($schema['properties']['nestedStringArrays']['items']['type'])->toBe('array')
+        ->and($schema['properties']['nestedStringArrays']['items'])->toHaveKey('items')
+        ->and($schema['properties']['nestedStringArrays']['items']['items']['type'])->toBe('string');
+        
+    // Check for nested arrays with array<array<int>> syntax
+    expect($schema['properties']['nestedIntArrays'])->toHaveKey('items')
+        ->and($schema['properties']['nestedIntArrays']['items'])->toHaveKey('type')
+        ->and($schema['properties']['nestedIntArrays']['items']['type'])->toBe('array')
+        ->and($schema['properties']['nestedIntArrays']['items'])->toHaveKey('items')
+        ->and($schema['properties']['nestedIntArrays']['items']['items']['type'])->toBe('integer');
+});
+
+test('parses object-like array syntax correctly', function () {
+    $method = new ReflectionMethod(DocBlockArrayTestStub::class, 'objectArraySyntax');
+    setupDocBlockExpectations($this->docBlockParserMock, $method);
+
+    $schema = $this->schemaGenerator->fromMethodParameters($method);
+
+    // Simple object array
+    expect($schema['properties']['person'])->toHaveKey('type')
+        ->and($schema['properties']['person']['type'])->toBe('object');
+    expect($schema['properties']['person'])->toHaveKey('properties')
+        ->and($schema['properties']['person']['properties'])->toHaveKeys(['name', 'age']);
+    expect($schema['properties']['person']['properties']['name']['type'])->toBe('string');
+    expect($schema['properties']['person']['properties']['age']['type'])->toBe('integer');
+    expect($schema['properties']['person'])->toHaveKey('required')
+        ->and($schema['properties']['person']['required'])->toContain('name')
+        ->and($schema['properties']['person']['required'])->toContain('age');
+        
+    // Object with nested array property
+    expect($schema['properties']['article'])->toHaveKey('properties')
+        ->and($schema['properties']['article']['properties'])->toHaveKey('tags')
+        ->and($schema['properties']['article']['properties']['tags']['type'])->toBe('array')
+        ->and($schema['properties']['article']['properties']['tags']['items']['type'])->toBe('string');
+        
+    // Complex object with nested object and array
+    expect($schema['properties']['order'])->toHaveKey('properties')
+        ->and($schema['properties']['order']['properties'])->toHaveKeys(['user', 'items']);
+    expect($schema['properties']['order']['properties']['user']['type'])->toBe('object');
+    expect($schema['properties']['order']['properties']['user']['properties'])->toHaveKeys(['id', 'name']);
+    expect($schema['properties']['order']['properties']['items']['type'])->toBe('array')
+        ->and($schema['properties']['order']['properties']['items']['items']['type'])->toBe('integer');
 });


### PR DESCRIPTION
This PR adds type-safe Schema attributes for JSON Schema validation and enhances the DocBlock parser to support rich array type definitions.

## New Features

### Schema Attribute System
- Added `#[Schema]` attribute to define precise JSON Schema constraints for parameters
- Created supporting classes:
  - `Format`: Constants for common string formats (EMAIL, DATE_TIME, etc.)
  - `ArrayItems`: For array item constraints
  - `Property`: For object property constraints
- Implemented constraint handling for strings, numbers, arrays, and objects
- Set up clear precedence: Schema attributes > DocBlock annotations > PHP type hints

### Enhanced DocBlock Array Type Parsing
- Improved array type inference from DocBlocks with support for:
  - Simple array syntax: `string[]`, `int[]`, `bool[]`
  - Generic array syntax: `array<string>`, `array<int>`
  - Nested arrays: `array<array<string>>`, `string[][]`
  - Object-like arrays: `array{name: string, age: int}`
- Added detection for complex nested structures
- Updated the parser to correctly identify object-like arrays vs regular arrays

### Testing
- Created test stubs demonstrating all array type scenarios
- Added tests verifying that constraints are correctly applied
- Ensured precedence is properly respected

## Documentation
- Updated README with new Schema attribute information
- Added examples of DocBlock array type usage
- Documented precedence rules