### PR TITLE
Fix tool name generation for invokable classes with MCP attributes

### DIFF
--- a/src/Definitions/PromptDefinition.php
+++ b/src/Definitions/PromptDefinition.php
@@ -44,8 +44,8 @@ class PromptDefinition
     {
         if (! preg_match(self::PROMPT_NAME_PATTERN, $this->promptName)) {
             throw new \InvalidArgumentException(
-                "Prompt name '{$this->promptName}' is invalid. Prompt names must match the pattern ".self::PROMPT_NAME_PATTERN
-                .' (alphanumeric characters, underscores, and hyphens only).'
+                "Prompt name '{$this->promptName}' is invalid. Prompt names must match the pattern " . self::PROMPT_NAME_PATTERN
+                    . ' (alphanumeric characters, underscores, and hyphens only).'
             );
         }
     }
@@ -98,7 +98,7 @@ class PromptDefinition
         }
         if (! empty($this->arguments)) {
             $data['arguments'] = array_map(
-                fn (PromptArgumentDefinition $arg) => $arg->toArray(),
+                fn(PromptArgumentDefinition $arg) => $arg->toArray(),
                 $this->arguments
             );
         }
@@ -141,6 +141,7 @@ class PromptDefinition
     ): self {
         $className = $method->getDeclaringClass()->getName();
         $methodName = $method->getName();
+        $promptName = $overrideName ?? ($methodName === '__invoke' ? $method->getDeclaringClass()->getShortName() : $methodName);
         $docBlock = $docBlockParser->parseDocBlock($method->getDocComment() ?: null);
         $description = $overrideDescription ?? $docBlockParser->getSummary($docBlock) ?? null;
 
@@ -155,14 +156,14 @@ class PromptDefinition
             }
 
             // Correctly get the specific Param tag using the '$' prefix
-            $paramTag = $paramTags['$'.$param->getName()] ?? null;
+            $paramTag = $paramTags['$' . $param->getName()] ?? null;
             $arguments[] = PromptArgumentDefinition::fromReflection($param, $paramTag);
         }
 
         return new self(
             className: $className,
             methodName: $methodName,
-            promptName: $overrideName ?? $methodName,
+            promptName: $promptName,
             description: $description,
             arguments: $arguments
         );

--- a/src/Definitions/ResourceDefinition.php
+++ b/src/Definitions/ResourceDefinition.php
@@ -58,15 +58,15 @@ class ResourceDefinition
     {
         if (! preg_match(self::URI_PATTERN, $this->uri)) {
             throw new \InvalidArgumentException(
-                "Resource URI '{$this->uri}' is invalid. URIs must match the pattern ".self::URI_PATTERN
-                .' (valid scheme followed by :// and optional path).'
+                "Resource URI '{$this->uri}' is invalid. URIs must match the pattern " . self::URI_PATTERN
+                    . ' (valid scheme followed by :// and optional path).'
             );
         }
 
         if (! preg_match(self::RESOURCE_NAME_PATTERN, $this->name)) {
             throw new \InvalidArgumentException(
-                "Resource name '{$this->name}' is invalid. Resource names must match the pattern ".self::RESOURCE_NAME_PATTERN
-                .' (alphanumeric characters, underscores, and hyphens only).'
+                "Resource name '{$this->name}' is invalid. Resource names must match the pattern " . self::RESOURCE_NAME_PATTERN
+                    . ' (alphanumeric characters, underscores, and hyphens only).'
             );
         }
     }
@@ -178,11 +178,15 @@ class ResourceDefinition
         $docBlock = $docBlockParser->parseDocBlock($method->getDocComment() ?: null);
         $description = $overrideDescription ?? $docBlockParser->getSummary($docBlock) ?? null;
 
+        $name = $overrideName ?? ($method->getName() === '__invoke'
+            ? $method->getDeclaringClass()->getShortName()
+            : $method->getName());
+
         return new self(
             className: $method->getDeclaringClass()->getName(),
             methodName: $method->getName(),
             uri: $uri,
-            name: $overrideName ?? $method->getName(),
+            name: $name,
             description: $description,
             mimeType: $mimeType,
             size: $size,

--- a/src/Definitions/ResourceTemplateDefinition.php
+++ b/src/Definitions/ResourceTemplateDefinition.php
@@ -56,14 +56,14 @@ class ResourceTemplateDefinition
         if (! preg_match(self::URI_TEMPLATE_PATTERN, $this->uriTemplate)) {
             throw new \InvalidArgumentException(
                 "Resource URI template '{$this->uriTemplate}' is invalid. URI templates must match the pattern "
-                .self::URI_TEMPLATE_PATTERN.' (valid scheme followed by :// and path with placeholder(s) in curly braces).'
+                    . self::URI_TEMPLATE_PATTERN . ' (valid scheme followed by :// and path with placeholder(s) in curly braces).'
             );
         }
 
         if (! preg_match(self::RESOURCE_NAME_PATTERN, $this->name)) {
             throw new \InvalidArgumentException(
-                "Resource name '{$this->name}' is invalid. Resource names must match the pattern ".self::RESOURCE_NAME_PATTERN
-                .' (alphanumeric characters, underscores, and hyphens only).'
+                "Resource name '{$this->name}' is invalid. Resource names must match the pattern " . self::RESOURCE_NAME_PATTERN
+                    . ' (alphanumeric characters, underscores, and hyphens only).'
             );
         }
     }
@@ -169,11 +169,15 @@ class ResourceTemplateDefinition
         $docBlock = $docBlockParser->parseDocBlock($method->getDocComment() ?: null);
         $description = $overrideDescription ?? $docBlockParser->getSummary($docBlock) ?? null;
 
+        $name = $overrideName ?? ($method->getName() === '__invoke'
+            ? $method->getDeclaringClass()->getShortName()
+            : $method->getName());
+
         return new self(
             className: $method->getDeclaringClass()->getName(),
             methodName: $method->getName(),
             uriTemplate: $uriTemplate,
-            name: $overrideName ?? $method->getName(),
+            name: $name,
             description: $description,
             mimeType: $mimeType,
             annotations: $annotations

--- a/src/Definitions/ToolDefinition.php
+++ b/src/Definitions/ToolDefinition.php
@@ -45,8 +45,8 @@ class ToolDefinition
     {
         if (! preg_match(self::TOOL_NAME_PATTERN, $this->toolName)) {
             throw new \InvalidArgumentException(
-                "Tool name '{$this->toolName}' is invalid. Tool names must match the pattern ".self::TOOL_NAME_PATTERN
-                .' (alphanumeric characters, underscores, and hyphens only).'
+                "Tool name '{$this->toolName}' is invalid. Tool names must match the pattern " . self::TOOL_NAME_PATTERN
+                    . ' (alphanumeric characters, underscores, and hyphens only).'
             );
         }
     }
@@ -137,10 +137,14 @@ class ToolDefinition
         $description = $overrideDescription ?? $docBlockParser->getSummary($docBlock) ?? null;
         $inputSchema = $schemaGenerator->fromMethodParameters($method);
 
+        $toolName = $overrideName ?? ($method->getName() === '__invoke'
+            ? $method->getDeclaringClass()->getShortName()
+            : $method->getName());
+
         return new self(
             className: $method->getDeclaringClass()->getName(),
             methodName: $method->getName(),
-            toolName: $overrideName ?? $method->getName(),
+            toolName: $toolName,
             description: $description,
             inputSchema: $inputSchema,
         );

--- a/tests/Mocks/DiscoveryStubs/ToolOnlyStub.php
+++ b/tests/Mocks/DiscoveryStubs/ToolOnlyStub.php
@@ -6,8 +6,8 @@ use PhpMcp\Server\Attributes\McpTool;
 
 class ToolOnlyStub
 {
+    public function __invoke(): void {}
+
     #[McpTool(name: 'tool-from-file1')]
-    public function tool1(): void
-    {
-    }
+    public function tool1(): void {}
 }


### PR DESCRIPTION
This PR fixes #12  where `#[McpTool]` and other MCP attributes on invokable classes were using `__invoke` as the default tool name instead of using the class's short name as documented in the `README`.