### PR TITLE
check the the header X-Forwarded-Proto for scheme

### DIFF
--- a/src/Transports/HttpServerTransport.php
+++ b/src/Transports/HttpServerTransport.php
@@ -184,8 +184,8 @@ class HttpServerTransport implements LoggerAwareInterface, LoopAwareInterface, S
             }
 
             try {
-                $postEndpointWithId = $this->messagePath . "?clientId={$clientId}";
-                $this->sendSseEvent($sseStream, 'endpoint', $postEndpointWithId, "init-{$clientId}");
+                $postEndpoint = $this->messagePath . "?clientId={$clientId}";
+                $this->sendSseEvent($sseStream, 'endpoint', $postEndpoint, "init-{$clientId}");
 
                 $this->emit('client_connected', [$clientId]);
             } catch (Throwable $e) {


### PR DESCRIPTION
Atm, when request to the `/mcp/sse` endoint via https (nginx proxy to the http transport server), it not respect the `X-Forwarded-Proto` in the header.

Hi, this is just a idea I made to make it work, I'm not sure how to proper handle the request scheme here

This is one sample from my app

```bash
curl -v https://mcp.daudau.cc/mcp/sse
* Host mcp.daudau.cc:443 was resolved.
* IPv6: (none)
* IPv4: 209.126.87.167
*   Trying 209.126.87.167:443...
* Connected to mcp.daudau.cc (209.126.87.167) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=mcp.daudau.cc
*  start date: Jun  9 09:05:53 2025 GMT
*  expire date: Sep  7 09:05:52 2025 GMT
*  subjectAltName: host "mcp.daudau.cc" matched cert's "mcp.daudau.cc"
*  issuer: C=US; O=Let's Encrypt; CN=E5
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://mcp.daudau.cc/mcp/sse
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: mcp.daudau.cc]
* [HTTP/2] [1] [:path: /mcp/sse]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /mcp/sse HTTP/2
> Host: mcp.daudau.cc
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< server: nginx
< date: Mon, 09 Jun 2025 11:34:40 GMT
< content-type: text/event-stream
< cache-control: no-cache
< access-control-allow-origin: *
< strict-transport-security: max-age=63072000
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
<
event: endpoint
id: init-sse_878e3e14eca21477a19082a458d393b6
data: http://mcp.daudau.cc/mcp/message?clientId=sse_878e3e14eca21477a19082a458d393b6
```