### PR TITLE
Fix: Require react/promise ^3.0 for Promise API Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "react/event-loop": "^1.5",
         "react/http": "^1.11",
+        "react/promise": "^3.0",
         "react/stream": "^1.4",
         "symfony/finder": "^6.4 || ^7.2"
     },


### PR DESCRIPTION
This PR addresses a runtime error where `Promise::catch()` is undefined. This occurs when a project using `php-mcp/server` has an older version of `react/promise` (e.g., v2.x) installed due to constraints from other packages or the project's own `composer.json`.