### PR TITLE
feat: add support for tool annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ $server->discover(basePath: __DIR__, scanDirs: ['src/Handlers']);
 
 Attributes:
 
-*   **`#[McpTool(name?, description?)`**: Defines an action. Parameters/return types/DocBlocks define the MCP schema. Use on public, non-static methods or invokable classes.
+*   **`#[McpTool(name?, description?, annotations?)`**: Defines an action. Parameters/return types/DocBlocks define the MCP schema. Use on public, non-static methods or invokable classes.
 *   **`#[McpResource(uri, name?, description?, mimeType?, size?, annotations?)]`**: Defines a static resource instance. Use on public, non-static methods or invokable classes. Method returns resource content.
 *   **`#[McpResourceTemplate(uriTemplate, name?, description?, mimeType?, annotations?)]`**: Defines a handler for templated URIs (e.g., `item://{id}`). Use on public, non-static methods or invokable classes. Method parameters must match template variables. Method returns content for the resolved instance.
 *   **`#[McpPrompt(name?, description?)`**: Defines a prompt generator. Use on public, non-static methods or invokable classes. Method parameters are prompt arguments. Method returns prompt messages.

--- a/src/Attributes/McpTool.php
+++ b/src/Attributes/McpTool.php
@@ -10,10 +10,12 @@ class McpTool
     /**
      * @param  string|null  $name  The name of the tool (defaults to the method name)
      * @param  string|null  $description  The description of the tool (defaults to the DocBlock/inferred)
+     * @param  array<string, mixed>  $annotations  Optional annotations following the MCP spec (e.g., ['title' => 'my title', 'readOnlyHint' => true]).
      */
     public function __construct(
         public ?string $name = null,
         public ?string $description = null,
+        public array $annotations = [],
     ) {
     }
 }

--- a/src/Definitions/ToolDefinition.php
+++ b/src/Definitions/ToolDefinition.php
@@ -18,11 +18,25 @@ class ToolDefinition
     private const TOOL_NAME_PATTERN = '/^[a-zA-Z0-9_-]+$/';
 
     /**
+     * Available tool annotations as defined by the MCP specification,
+     * and a validator function for each.
+     */
+    private const VALID_ANNOTATION_KEYS = [
+        'title' => 'is_string',
+        'readOnlyHint' => 'is_bool',
+        'destructiveHint' => 'is_bool',
+        'idempotentHint' => 'is_bool',
+        'openWorldHint' => 'is_bool',
+
+    ];
+
+    /**
      * @param  class-string  $className  The fully qualified class name containing the tool method.
      * @param  string  $methodName  The name of the PHP method implementing the tool.
      * @param  string  $toolName  The designated name of the MCP tool (used in 'tools/call' requests).
      * @param  string|null  $description  A human-readable description of the tool.
      * @param  array<string, mixed>  $inputSchema  A JSON Schema object (as a PHP array) defining the expected 'arguments' for the tool. Complies with MCP 'Tool.inputSchema'.
+     * @param  array<string, mixed>  $annotations  Optional annotations (title, readOnlyHint, destructiveHint).
      *
      * @throws \InvalidArgumentException If the tool name doesn't match the required pattern.
      */
@@ -32,6 +46,7 @@ class ToolDefinition
         public readonly string $toolName,
         public readonly ?string $description,
         public readonly array $inputSchema,
+        public readonly array $annotations = [],
     ) {
         $this->validate();
     }
@@ -48,6 +63,22 @@ class ToolDefinition
                 "Tool name '{$this->toolName}' is invalid. Tool names must match the pattern " . self::TOOL_NAME_PATTERN
                     . ' (alphanumeric characters, underscores, and hyphens only).'
             );
+        }
+
+        foreach ($this->annotations as $key => $value) {
+            // Check there are no invalid annotations keys
+            if (! array_key_exists($key, self::VALID_ANNOTATION_KEYS)) {
+                throw new \InvalidArgumentException("Invalid annotation key '{$key}' in tool '{$this->toolName}'.");
+            }
+
+            // Check annotations values match defined types
+            $validator = self::VALID_ANNOTATION_KEYS[$key];
+            if (! $validator($value)) {
+                throw new \InvalidArgumentException(
+                    "Annotation '{$key}' for tool '{$this->toolName}' must be of type "
+                    . gettype($value) . ', expected ' . gettype($validator(null))
+                );
+            }
         }
     }
 
@@ -82,6 +113,14 @@ class ToolDefinition
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    public function getAnnotations(): array
+    {
+        return $this->annotations;
+    }
+
+    /**
      * Convert the tool definition to MCP format.
      */
     public function toArray(): array
@@ -96,6 +135,10 @@ class ToolDefinition
 
         if ($this->inputSchema) {
             $result['inputSchema'] = $this->inputSchema;
+        }
+
+        if ($this->annotations) {
+            $result['annotations'] = $this->annotations;
         }
 
         return $result;
@@ -115,6 +158,7 @@ class ToolDefinition
             toolName: $data['toolName'],
             description: $data['description'],
             inputSchema: $data['inputSchema'],
+            annotations: $data['annotations'] ?? []
         );
     }
 
@@ -130,12 +174,14 @@ class ToolDefinition
         ReflectionMethod $method,
         ?string $overrideName,
         ?string $overrideDescription,
+        ?array $overrideAnnotations,
         DocBlockParser $docBlockParser,
         SchemaGenerator $schemaGenerator
     ): self {
         $docBlock = $docBlockParser->parseDocBlock($method->getDocComment() ?? null);
         $description = $overrideDescription ?? $docBlockParser->getSummary($docBlock) ?? null;
         $inputSchema = $schemaGenerator->fromMethodParameters($method);
+        $annotations = $overrideAnnotations ?? null;
 
         $toolName = $overrideName ?? ($method->getName() === '__invoke'
             ? $method->getDeclaringClass()->getShortName()
@@ -147,6 +193,7 @@ class ToolDefinition
             toolName: $toolName,
             description: $description,
             inputSchema: $inputSchema,
+            annotations: $annotations ?? []
         );
     }
 }

--- a/src/ServerBuilder.php
+++ b/src/ServerBuilder.php
@@ -126,9 +126,9 @@ final class ServerBuilder
     /**
      * Manually registers a tool handler.
      */
-    public function withTool(array|string $handler, ?string $name = null, ?string $description = null): self
+    public function withTool(array|string $handler, ?string $name = null, ?string $description = null, array $annotations = []): self
     {
-        $this->manualTools[] = compact('handler', 'name', 'description');
+        $this->manualTools[] = compact('handler', 'name', 'description', 'annotations');
 
         return $this;
     }
@@ -225,6 +225,7 @@ final class ServerBuilder
                     $resolvedHandler['reflectionMethod'],
                     $data['name'],
                     $data['description'],
+                    $data['annotations'],
                     $docBlockParser,
                     $schemaGenerator
                 );

--- a/src/Support/Discoverer.php
+++ b/src/Support/Discoverer.php
@@ -202,6 +202,7 @@ class Discoverer
                         $method,
                         $instance->name ?? null,
                         $instance->description ?? null,
+                        $instance->annotations ?? [],
                         $this->docBlockParser,
                         $this->schemaGenerator
                     );

--- a/tests/Unit/Attributes/McpToolTest.php
+++ b/tests/Unit/Attributes/McpToolTest.php
@@ -8,13 +8,15 @@ it('instantiates with correct properties', function () {
     // Arrange
     $name = 'test-tool-name';
     $description = 'This is a test description.';
+    $annotations = ['title' => 'Test Tool', 'readOnlyHint' => true];
 
     // Act
-    $attribute = new McpTool(name: $name, description: $description);
+    $attribute = new McpTool(name: $name, description: $description, annotations: $annotations);
 
     // Assert
     expect($attribute->name)->toBe($name);
     expect($attribute->description)->toBe($description);
+    expect($attribute->annotations)->toBe($annotations);
 });
 
 it('instantiates with null values for name and description', function () {
@@ -24,6 +26,7 @@ it('instantiates with null values for name and description', function () {
     // Assert
     expect($attribute->name)->toBeNull();
     expect($attribute->description)->toBeNull();
+    expect($attribute->annotations)->toBe([]);
 });
 
 it('instantiates with missing optional arguments', function () {
@@ -33,4 +36,28 @@ it('instantiates with missing optional arguments', function () {
     // Assert
     expect($attribute->name)->toBeNull();
     expect($attribute->description)->toBeNull();
+    expect($attribute->annotations)->toBe([]);
+});
+
+it('instantiates with only annotations provided', function () {
+    // Arrange
+    $annotations = ['destructiveHint' => true, 'category' => 'admin'];
+
+    // Act
+    $attribute = new McpTool(annotations: $annotations);
+
+    // Assert
+    expect($attribute->name)->toBeNull();
+    expect($attribute->description)->toBeNull();
+    expect($attribute->annotations)->toBe($annotations);
+});
+
+it('instantiates with empty annotations array', function () {
+    // Arrange & Act
+    $attribute = new McpTool(name: 'test', description: 'test desc', annotations: []);
+
+    // Assert
+    expect($attribute->name)->toBe('test');
+    expect($attribute->description)->toBe('test desc');
+    expect($attribute->annotations)->toBe([]);
 });

--- a/tests/Unit/ServerBuilderTest.php
+++ b/tests/Unit/ServerBuilderTest.php
@@ -99,7 +99,7 @@ it('stores manual tool registration data', function () {
 
     $manualTools = getBuilderProperty($this->builder, 'manualTools');
     expect($manualTools)->toBeArray()->toHaveCount(1);
-    expect($manualTools[0])->toBe(['handler' => $handler, 'name' => $name, 'description' => $desc]);
+    expect($manualTools[0])->toBe(['handler' => $handler, 'name' => $name, 'description' => $desc, 'annotations' => []]);
 });
 
 it('stores manual resource registration data', function () {


### PR DESCRIPTION
This PR adds support for Tool Annotations, added in the [2025-03-26 version of the MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#tool).

* McpTool has been updated to support this.
* Defaults have been defined to handle backwards compatibility everywhere
* Should handle parsing via reflection and direct definition.
* Tests written.
* Docs updated.

Happy to take suggestions/feedback/etc.

Thanks for writing and maintaining this library!