### PR TITLE
Streamline Registry Notifications and Add Discovery Suppression Support

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -118,7 +118,7 @@ class Registry
         $this->notificationsEnabled = false;
     }
 
-    public function notifyToolsChanged(): void
+    public function notifyToolsListChanged(): void
     {
         if (!$this->notificationsEnabled || !$this->clientStateManager) {
             return;
@@ -133,7 +133,7 @@ class Registry
         $this->clientStateManager->queueMessageForAll($framedMessage);
     }
 
-    public function notifyResourcesChanged(): void
+    public function notifyResourcesListChanged(): void
     {
         if (!$this->notificationsEnabled || !$this->clientStateManager) {
             return;
@@ -148,7 +148,7 @@ class Registry
         $this->clientStateManager->queueMessageForAll($framedMessage);
     }
 
-    public function notifyPromptsChanged(): void
+    public function notifyPromptsListChanged(): void
     {
         if (!$this->notificationsEnabled || !$this->clientStateManager) {
             return;
@@ -220,7 +220,7 @@ class Registry
         }
 
         if (! $exists) {
-            $this->notifyToolsChanged();
+            $this->notifyToolsListChanged();
         }
     }
 
@@ -247,7 +247,7 @@ class Registry
         }
 
         if (! $exists) {
-            $this->notifyResourcesChanged();
+            $this->notifyResourcesListChanged();
         }
     }
 
@@ -298,7 +298,7 @@ class Registry
         }
 
         if (! $exists) {
-            $this->notifyPromptsChanged();
+            $this->notifyPromptsListChanged();
         }
     }
 

--- a/tests/Unit/RegistryTest.php
+++ b/tests/Unit/RegistryTest.php
@@ -378,7 +378,7 @@ it('removes only non-manual elements and optionally clears cache', function ($de
 
 // --- Notifier Tests ---
 
-it('default notifiers send messages via ClientStateManager', function () {
+it('sends notifications when tools, resources, and prompts are registered', function () {
     // Arrange
     $tool = createTestTool('notify-tool');
     $resource = createTestResource('notify://res');
@@ -392,18 +392,12 @@ it('default notifiers send messages via ClientStateManager', function () {
     $this->registry->registerPrompt($prompt);
 });
 
-it('custom notifiers can be set and are called', function () {
+it('does not send notifications when notifications are disabled', function () {
     // Arrange
-    $toolNotifierCalled = false;
-    $this->registry->setToolsChangedNotifier(function () use (&$toolNotifierCalled) {
-        $toolNotifierCalled = true;
-    });
+    $this->registry->disableNotifications();
 
     $this->clientStateManager->shouldNotReceive('queueMessageForAll');
 
     // Act
-    $this->registry->registerTool(createTestTool('custom-notify'));
-
-    // Assert
-    expect($toolNotifierCalled)->toBeTrue();
+    $this->registry->registerTool(createTestTool('notify-tool'));
 });


### PR DESCRIPTION
- Deprecated support for custom notifier callbacks, handled internally. 
- Added list changed notification and resource changed methods directly to Registry.
- New: Enable/disable notifications in registry, which is useful for suppressing notifications during initial discovery/registration.