### PR TITLE
Fix validation failure for MCP tools without parameters

### DIFF
--- a/examples/02-discovery-http-userprofile/McpElements.php
+++ b/examples/02-discovery-http-userprofile/McpElements.php
@@ -99,6 +99,12 @@ class McpElements
         return ['success' => true, 'message_sent' => $message];
     }
 
+    #[McpTool(name: 'test_tool_without_params')]
+    public function testToolWithoutParams()
+    {
+        return ['success' => true, 'message' => 'Test tool without params'];
+    }
+
     /**
      * Generates a prompt to write a bio for a user.
      *

--- a/examples/02-discovery-http-userprofile/server.php
+++ b/examples/02-discovery-http-userprofile/server.php
@@ -74,8 +74,8 @@ try {
 
     $server->discover(__DIR__, ['.']);
 
-    $transport = new HttpServerTransport('127.0.0.1', 8080, 'mcp');
-    // $transport = new StreamableHttpServerTransport('127.0.0.1', 8080, 'mcp');
+    // $transport = new HttpServerTransport('127.0.0.1', 8080, 'mcp');
+    $transport = new StreamableHttpServerTransport('127.0.0.1', 8080, 'mcp');
 
     $server->listen($transport);
 

--- a/src/Utils/SchemaValidator.php
+++ b/src/Utils/SchemaValidator.php
@@ -32,6 +32,10 @@ class SchemaValidator
      */
     public function validateAgainstJsonSchema(mixed $data, array|object $schema): array
     {
+        if (is_array($data) && empty($data)) {
+            $data = new \stdClass();
+        }
+
         try {
             // --- Schema Preparation ---
             if (is_array($schema)) {
@@ -192,7 +196,7 @@ class SchemaValidator
         switch (strtolower($keyword)) {
             case 'required':
                 $missing = $args['missing'] ?? [];
-                $formattedMissing = implode(', ', array_map(fn ($p) => "`{$p}`", $missing));
+                $formattedMissing = implode(', ', array_map(fn($p) => "`{$p}`", $missing));
                 $message = "Missing required properties: {$formattedMissing}.";
                 break;
             case 'type':
@@ -286,7 +290,7 @@ class SchemaValidator
                 break;
             case 'additionalProperties': // Corrected casing
                 $unexpected = $args['properties'] ?? [];
-                $formattedUnexpected = implode(', ', array_map(fn ($p) => "`{$p}`", $unexpected));
+                $formattedUnexpected = implode(', ', array_map(fn($p) => "`{$p}`", $unexpected));
                 $message = "Object contains unexpected additional properties: {$formattedUnexpected}.";
                 break;
             case 'format':


### PR DESCRIPTION
Tools with no parameters fail validation in v3.0.0 with the error: `Invalid type. Expected object, but received unknown.`

This is a regression from v2.x where such tools worked correctly.

Fixes #26 