### PR TITLE
Refactor: expose session garbage collection method for integration

### DIFF
--- a/src/Contracts/SessionInterface.php
+++ b/src/Contracts/SessionInterface.php
@@ -79,4 +79,11 @@ interface SessionInterface extends JsonSerializable
      * Check if there are any messages in the queue.
      */
     public function hasQueuedMessages(): bool;
+
+    /**
+     * Get the session handler instance.
+     *
+     * @return SessionHandlerInterface
+     */
+    public function getHandler(): SessionHandlerInterface;
 }


### PR DESCRIPTION
This PR includes several improvements to the Session management to allow for external integrations. 

- Add `getHandler()` method to `SessionInterface` and `Session` class
- Refactor `Session` constructor to accept optional `$data` parameter 
- Add static `Session::make()` method for cleaner session creation with null return capability
- Exposing session garbage collection functionality for integration