### PR TITLE
fix(cache): handle missing session in index for CacheSessionHandler

### DIFF
--- a/src/Session/CacheSessionHandler.php
+++ b/src/Session/CacheSessionHandler.php
@@ -27,7 +27,7 @@ class CacheSessionHandler implements SessionHandlerInterface
     public function read(string $sessionId): string|false
     {
         $session = $this->cache->get($sessionId, false);
-        if ($session === false) {
+        if ($session === false || !isset($this->sessionIndex[$sessionId])) {
             return false;
         }
 


### PR DESCRIPTION
Improves `read()` logic in CacheSessionHandler to gracefully handle cases where the session is cleared or missing in the session index.