### PR TITLE
Fix: implement proper MCP protocol version negotiation

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -119,16 +119,13 @@ class Dispatcher
 
     public function handleInitialize(InitializeRequest $request, SessionInterface $session): InitializeResult
     {
-        if (! in_array($request->protocolVersion, Protocol::SUPPORTED_PROTOCOL_VERSIONS)) {
-            $this->logger->warning("Unsupported protocol version: {$request->protocolVersion}", [
-                'supportedVersions' => Protocol::SUPPORTED_PROTOCOL_VERSIONS,
-            ]);
+        if (in_array($request->protocolVersion, Protocol::SUPPORTED_PROTOCOL_VERSIONS)) {
+            $protocolVersion = $request->protocolVersion;
+        } else {
+            $protocolVersion = Protocol::LATEST_PROTOCOL_VERSION;
         }
 
-        $protocolVersion = Protocol::LATEST_PROTOCOL_VERSION;
-
         $session->set('client_info', $request->clientInfo);
-
 
         $serverInfo = $this->configuration->serverInfo;
         $capabilities = $this->configuration->capabilities;

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -125,7 +125,8 @@ class Dispatcher
             $protocolVersion = Protocol::LATEST_PROTOCOL_VERSION;
         }
 
-        $session->set('client_info', $request->clientInfo);
+        $session->set('client_info', $request->clientInfo->toArray());
+        $session->set('protocol_version', $protocolVersion);
 
         $serverInfo = $this->configuration->serverInfo;
         $capabilities = $this->configuration->capabilities;

--- a/tests/Unit/DispatcherTest.php
+++ b/tests/Unit/DispatcherTest.php
@@ -100,7 +100,7 @@ it('routes to handleInitialize for initialize request', function () {
             'capabilities' => [],
         ]
     );
-    $this->session->shouldReceive('set')->with('client_info', Mockery::on(fn ($value) => $value->name === 'client' && $value->version === '1.0'))->once();
+    $this->session->shouldReceive('set')->with('client_info', Mockery::on(fn($value) => $value->name === 'client' && $value->version === '1.0'))->once();
 
     $result = $this->dispatcher->handleRequest($request, $this->session);
     expect($result)->toBeInstanceOf(InitializeResult::class);
@@ -135,6 +135,30 @@ it('does nothing for unknown notification method', function () {
 it('can handle initialize request', function () {
     $clientInfo = Implementation::make('TestClient', '0.9.9');
     $request = InitializeRequest::make(1, Protocol::LATEST_PROTOCOL_VERSION, ClientCapabilities::make(), $clientInfo, []);
+    $this->session->shouldReceive('set')->with('client_info', $clientInfo)->once();
+
+    $result = $this->dispatcher->handleInitialize($request, $this->session);
+    expect($result->protocolVersion)->toBe(Protocol::LATEST_PROTOCOL_VERSION);
+    expect($result->serverInfo->name)->toBe('DispatcherTestServer');
+    expect($result->capabilities)->toBeInstanceOf(ServerCapabilities::class);
+});
+
+it('can handle initialize request with older supported protocol version', function () {
+    $clientInfo = Implementation::make('TestClient', '0.9.9');
+    $clientRequestedVersion = '2024-11-05';
+    $request = InitializeRequest::make(1, $clientRequestedVersion, ClientCapabilities::make(), $clientInfo, []);
+    $this->session->shouldReceive('set')->with('client_info', $clientInfo)->once();
+
+    $result = $this->dispatcher->handleInitialize($request, $this->session);
+    expect($result->protocolVersion)->toBe($clientRequestedVersion);
+    expect($result->serverInfo->name)->toBe('DispatcherTestServer');
+    expect($result->capabilities)->toBeInstanceOf(ServerCapabilities::class);
+});
+
+it('can handle initialize request with unsupported protocol version', function () {
+    $clientInfo = Implementation::make('TestClient', '0.9.9');
+    $unsupportedVersion = '1999-01-01';
+    $request = InitializeRequest::make(1, $unsupportedVersion, ClientCapabilities::make(), $clientInfo, []);
     $this->session->shouldReceive('set')->with('client_info', $clientInfo)->once();
 
     $result = $this->dispatcher->handleInitialize($request, $this->session);
@@ -256,14 +280,14 @@ it('can handle resources list request and return paginated resources', function 
     $requestP1 = ListResourcesRequest::make(1);
     $resultP1 = $this->dispatcher->handleResourcesList($requestP1);
     expect($resultP1->resources)->toHaveCount(DISPATCHER_PAGINATION_LIMIT);
-    expect(array_map(fn ($r) => $r->name, $resultP1->resources))->toEqual(['Resource1', 'Resource2', 'Resource3']);
+    expect(array_map(fn($r) => $r->name, $resultP1->resources))->toEqual(['Resource1', 'Resource2', 'Resource3']);
     expect($resultP1->nextCursor)->toBe(base64_encode('offset=3'));
 
     // Page 2
     $requestP2 = ListResourcesRequest::make(2, $resultP1->nextCursor);
     $resultP2 = $this->dispatcher->handleResourcesList($requestP2);
     expect($resultP2->resources)->toHaveCount(2);
-    expect(array_map(fn ($r) => $r->name, $resultP2->resources))->toEqual(['Resource4', 'Resource5']);
+    expect(array_map(fn($r) => $r->name, $resultP2->resources))->toEqual(['Resource4', 'Resource5']);
     expect($resultP2->nextCursor)->toBeNull();
 });
 
@@ -288,14 +312,14 @@ it('can handle resource template list request and return paginated templates', f
     $requestP1 = ListResourceTemplatesRequest::make(1);
     $resultP1 = $this->dispatcher->handleResourceTemplateList($requestP1);
     expect($resultP1->resourceTemplates)->toHaveCount(DISPATCHER_PAGINATION_LIMIT);
-    expect(array_map(fn ($rt) => $rt->name, $resultP1->resourceTemplates))->toEqual(['Template1', 'Template2', 'Template3']);
+    expect(array_map(fn($rt) => $rt->name, $resultP1->resourceTemplates))->toEqual(['Template1', 'Template2', 'Template3']);
     expect($resultP1->nextCursor)->toBe(base64_encode('offset=3'));
 
     // Page 2
     $requestP2 = ListResourceTemplatesRequest::make(2, $resultP1->nextCursor);
     $resultP2 = $this->dispatcher->handleResourceTemplateList($requestP2);
     expect($resultP2->resourceTemplates)->toHaveCount(1);
-    expect(array_map(fn ($rt) => $rt->name, $resultP2->resourceTemplates))->toEqual(['Template4']);
+    expect(array_map(fn($rt) => $rt->name, $resultP2->resourceTemplates))->toEqual(['Template4']);
     expect($resultP2->nextCursor)->toBeNull();
 });
 
@@ -345,14 +369,14 @@ it('can handle prompts list request and return paginated prompts', function () {
     $requestP1 = ListPromptsRequest::make(1);
     $resultP1 = $this->dispatcher->handlePromptsList($requestP1);
     expect($resultP1->prompts)->toHaveCount(DISPATCHER_PAGINATION_LIMIT);
-    expect(array_map(fn ($p) => $p->name, $resultP1->prompts))->toEqual(['promptA', 'promptB', 'promptC']);
+    expect(array_map(fn($p) => $p->name, $resultP1->prompts))->toEqual(['promptA', 'promptB', 'promptC']);
     expect($resultP1->nextCursor)->toBe(base64_encode('offset=3'));
 
     // Page 2
     $requestP2 = ListPromptsRequest::make(2, $resultP1->nextCursor);
     $resultP2 = $this->dispatcher->handlePromptsList($requestP2);
     expect($resultP2->prompts)->toHaveCount(DISPATCHER_PAGINATION_LIMIT); // 3 more
-    expect(array_map(fn ($p) => $p->name, $resultP2->prompts))->toEqual(['promptD', 'promptE', 'promptF']);
+    expect(array_map(fn($p) => $p->name, $resultP2->prompts))->toEqual(['promptD', 'promptE', 'promptF']);
     expect($resultP2->nextCursor)->toBeNull(); // End of list
 });
 


### PR DESCRIPTION
## Changes

- **Protocol version negotiation**: Server now responds with client's requested version if supported, otherwise falls back to latest version
- **Session storage**: Store negotiated protocol version in session for future use
- **Test coverage**: Added test cases for both supported and unsupported version scenarios

Fixes #34