### PR TITLE
feat:  use callable instead of Closure|array|string for handler type

### DIFF
--- a/src/Elements/RegisteredElement.php
+++ b/src/Elements/RegisteredElement.php
@@ -18,10 +18,17 @@ use TypeError;
 
 class RegisteredElement implements JsonSerializable
 {
+    /** @var callable|array|string */
+    public readonly mixed $handler;
+    public readonly bool $isManual;
+
     public function __construct(
-        public readonly \Closure|array|string $handler,
-        public readonly bool $isManual = false,
-    ) {}
+        callable|array|string $handler,
+        bool $isManual = false,
+    ) {
+        $this->handler = $handler;
+        $this->isManual = $isManual;
+    }
 
     public function handle(ContainerInterface $container, array $arguments): mixed
     {

--- a/src/Elements/RegisteredPrompt.php
+++ b/src/Elements/RegisteredPrompt.php
@@ -24,14 +24,14 @@ class RegisteredPrompt extends RegisteredElement
 {
     public function __construct(
         public readonly Prompt $schema,
-        \Closure|array|string $handler,
+        callable|array|string $handler,
         bool $isManual = false,
         public readonly array $completionProviders = []
     ) {
         parent::__construct($handler, $isManual);
     }
 
-    public static function make(Prompt $schema, \Closure|array|string $handler, bool $isManual = false, array $completionProviders = []): self
+    public static function make(Prompt $schema, callable|array|string $handler, bool $isManual = false, array $completionProviders = []): self
     {
         return new self($schema, $handler, $isManual, $completionProviders);
     }

--- a/src/Elements/RegisteredResource.php
+++ b/src/Elements/RegisteredResource.php
@@ -16,13 +16,13 @@ class RegisteredResource extends RegisteredElement
 {
     public function __construct(
         public readonly Resource $schema,
-        \Closure|array|string $handler,
+        callable|array|string $handler,
         bool $isManual = false,
     ) {
         parent::__construct($handler, $isManual);
     }
 
-    public static function make(Resource $schema, \Closure|array|string $handler, bool $isManual = false): self
+    public static function make(Resource $schema, callable|array|string $handler, bool $isManual = false): self
     {
         return new self($schema, $handler, $isManual);
     }

--- a/src/Elements/RegisteredResourceTemplate.php
+++ b/src/Elements/RegisteredResourceTemplate.php
@@ -22,7 +22,7 @@ class RegisteredResourceTemplate extends RegisteredElement
 
     public function __construct(
         public readonly ResourceTemplate $schema,
-        \Closure|array|string $handler,
+        callable|array|string $handler,
         bool $isManual = false,
         public readonly array $completionProviders = []
     ) {
@@ -31,7 +31,7 @@ class RegisteredResourceTemplate extends RegisteredElement
         $this->compileTemplate();
     }
 
-    public static function make(ResourceTemplate $schema, \Closure|array|string $handler, bool $isManual = false, array $completionProviders = []): self
+    public static function make(ResourceTemplate $schema, callable|array|string $handler, bool $isManual = false, array $completionProviders = []): self
     {
         return new self($schema, $handler, $isManual, $completionProviders);
     }

--- a/src/Elements/RegisteredTool.php
+++ b/src/Elements/RegisteredTool.php
@@ -14,13 +14,13 @@ class RegisteredTool extends RegisteredElement
 {
     public function __construct(
         public readonly Tool $schema,
-        \Closure|array|string $handler,
+        callable|array|string $handler,
         bool $isManual = false,
     ) {
         parent::__construct($handler, $isManual);
     }
 
-    public static function make(Tool $schema, \Closure|array|string $handler, bool $isManual = false): self
+    public static function make(Tool $schema, callable|array|string $handler, bool $isManual = false): self
     {
         return new self($schema, $handler, $isManual);
     }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -181,7 +181,7 @@ class Registry implements EventEmitterInterface
         }
     }
 
-    public function registerTool(Tool $tool, \Closure|array|string $handler, bool $isManual = false): void
+    public function registerTool(Tool $tool, callable|array|string $handler, bool $isManual = false): void
     {
         $toolName = $tool->name;
         $existing = $this->tools[$toolName] ?? null;
@@ -197,7 +197,7 @@ class Registry implements EventEmitterInterface
         $this->checkAndEmitChange('tools', $this->tools);
     }
 
-    public function registerResource(Resource $resource, \Closure|array|string $handler, bool $isManual = false): void
+    public function registerResource(Resource $resource, callable|array|string $handler, bool $isManual = false): void
     {
         $uri = $resource->uri;
         $existing = $this->resources[$uri] ?? null;
@@ -215,7 +215,7 @@ class Registry implements EventEmitterInterface
 
     public function registerResourceTemplate(
         ResourceTemplate $template,
-        \Closure|array|string $handler,
+        callable|array|string $handler,
         array $completionProviders = [],
         bool $isManual = false,
     ): void {
@@ -235,7 +235,7 @@ class Registry implements EventEmitterInterface
 
     public function registerPrompt(
         Prompt $prompt,
-        \Closure|array|string $handler,
+        callable|array|string $handler,
         array $completionProviders = [],
         bool $isManual = false,
     ): void {

--- a/src/ServerBuilder.php
+++ b/src/ServerBuilder.php
@@ -215,7 +215,7 @@ final class ServerBuilder
     /**
      * Manually registers a tool handler.
      */
-    public function withTool(\Closure|array|string $handler, ?string $name = null, ?string $description = null, ?ToolAnnotations $annotations = null, ?array $inputSchema = null): self
+    public function withTool(callable|array|string $handler, ?string $name = null, ?string $description = null, ?ToolAnnotations $annotations = null, ?array $inputSchema = null): self
     {
         $this->manualTools[] = compact('handler', 'name', 'description', 'annotations', 'inputSchema');
 
@@ -225,7 +225,7 @@ final class ServerBuilder
     /**
      * Manually registers a resource handler.
      */
-    public function withResource(\Closure|array|string $handler, string $uri, ?string $name = null, ?string $description = null, ?string $mimeType = null, ?int $size = null, ?Annotations $annotations = null): self
+    public function withResource(callable|array|string $handler, string $uri, ?string $name = null, ?string $description = null, ?string $mimeType = null, ?int $size = null, ?Annotations $annotations = null): self
     {
         $this->manualResources[] = compact('handler', 'uri', 'name', 'description', 'mimeType', 'size', 'annotations');
 
@@ -235,7 +235,7 @@ final class ServerBuilder
     /**
      * Manually registers a resource template handler.
      */
-    public function withResourceTemplate(\Closure|array|string $handler, string $uriTemplate, ?string $name = null, ?string $description = null, ?string $mimeType = null, ?Annotations $annotations = null): self
+    public function withResourceTemplate(callable|array|string $handler, string $uriTemplate, ?string $name = null, ?string $description = null, ?string $mimeType = null, ?Annotations $annotations = null): self
     {
         $this->manualResourceTemplates[] = compact('handler', 'uriTemplate', 'name', 'description', 'mimeType', 'annotations');
 
@@ -245,7 +245,7 @@ final class ServerBuilder
     /**
      * Manually registers a prompt handler.
      */
-    public function withPrompt(\Closure|array|string $handler, ?string $name = null, ?string $description = null): self
+    public function withPrompt(callable|array|string $handler, ?string $name = null, ?string $description = null): self
     {
         $this->manualPrompts[] = compact('handler', 'name', 'description');
 

--- a/tests/Unit/Attributes/CompletionProviderTest.php
+++ b/tests/Unit/Attributes/CompletionProviderTest.php
@@ -8,13 +8,7 @@ use PhpMcp\Server\Attributes\CompletionProvider;
 use PhpMcp\Server\Tests\Fixtures\General\CompletionProviderFixture;
 use PhpMcp\Server\Defaults\ListCompletionProvider;
 use PhpMcp\Server\Defaults\EnumCompletionProvider;
-
-enum TestEnum: string
-{
-    case DRAFT = 'draft';
-    case PUBLISHED = 'published';
-    case ARCHIVED = 'archived';
-}
+use PhpMcp\Server\Tests\Fixtures\Enums\StatusEnum;
 
 it('can be constructed with provider class', function () {
     $attribute = new CompletionProvider(provider: CompletionProviderFixture::class);
@@ -43,11 +37,11 @@ it('can be constructed with values array', function () {
 });
 
 it('can be constructed with enum class', function () {
-    $attribute = new CompletionProvider(enum: TestEnum::class);
+    $attribute = new CompletionProvider(enum: StatusEnum::class);
 
     expect($attribute->provider)->toBeNull();
     expect($attribute->values)->toBeNull();
-    expect($attribute->enum)->toBe(TestEnum::class);
+    expect($attribute->enum)->toBe(StatusEnum::class);
 });
 
 it('throws exception when no parameters provided', function () {
@@ -65,6 +59,6 @@ it('throws exception when all parameters provided', function () {
     new CompletionProvider(
         provider: CompletionProviderFixture::class,
         values: ['test'],
-        enum: TestEnum::class
+        enum: StatusEnum::class
     );
 })->throws(\InvalidArgumentException::class, 'Only one of provider, values, or enum can be set');

--- a/tests/Unit/Elements/RegisteredPromptTest.php
+++ b/tests/Unit/Elements/RegisteredPromptTest.php
@@ -12,6 +12,7 @@ use PhpMcp\Schema\Content\TextContent;
 use PhpMcp\Schema\Content\ImageContent;
 use PhpMcp\Schema\Content\AudioContent;
 use PhpMcp\Schema\Content\EmbeddedResource;
+use PhpMcp\Server\Tests\Fixtures\Enums\StatusEnum;
 use PhpMcp\Server\Tests\Fixtures\General\PromptHandlerFixture;
 use PhpMcp\Server\Tests\Fixtures\General\CompletionProviderFixture;
 use PhpMcp\Server\Tests\Unit\Attributes\TestEnum;
@@ -261,7 +262,7 @@ it('can be serialized with EnumCompletionProvider instances', function () {
         [PromptArgument::make('priority')]
     );
 
-    $enumProvider = new \PhpMcp\Server\Defaults\EnumCompletionProvider(TestEnum::class);
+    $enumProvider = new \PhpMcp\Server\Defaults\EnumCompletionProvider(StatusEnum::class);
     $providers = ['priority' => $enumProvider];
 
     $original = RegisteredPrompt::make(


### PR DESCRIPTION
This PR updates handler type hints from `\Closure|array|string` to `callable|array|string` throughout the codebase.

## Changes
- Updated all RegisteredElement classes to use `callable` type hint
- Fixed RegisteredElement constructor to properly handle callable parameter
- Updated ServerBuilder and Registry method signatures

## Why
The `callable` type hint is more semantically correct and covers the same use cases as `\Closure|array|string` but is cleaner and more inclusive.

## Breaking Changes
None - this is a type hint improvement that maintains backward compatibility.