### PR TITLE
feat: Pass `CallContext` (with Request data) to MCP Tool invocation

### DIFF
--- a/src/CallContext.php
+++ b/src/CallContext.php
@@ -1,9 +1,0 @@
-<?php declare(strict_types = 1);
-namespace PhpMcp\Server;
-
-use Psr\Http\Message\ServerRequestInterface;
-
-class CallContext
-{
-    public ?ServerRequestInterface $request = null;
-}

--- a/src/CallContext.php
+++ b/src/CallContext.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+namespace PhpMcp\Server;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class CallContext
+{
+    public ?ServerRequestInterface $request = null;
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -7,8 +7,8 @@ use Psr\Http\Message\ServerRequestInterface;
 final class Context
 {
     public function __construct(
-        public readonly ?ServerRequestInterface $request,
-        public readonly SessionInterface $session
+        public readonly SessionInterface $session,
+        public readonly ?ServerRequestInterface $request = null,
     )
     {
     }

--- a/src/Context.php
+++ b/src/Context.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+namespace PhpMcp\Server;
+
+use PhpMcp\Server\Contracts\SessionInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class Context
+{
+    public function __construct(
+        public readonly ?ServerRequestInterface $request,
+        public readonly SessionInterface $session
+    )
+    {
+    }
+}

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -61,7 +61,7 @@ class Dispatcher
         $this->schemaValidator ??= new SchemaValidator($this->logger);
     }
 
-    public function handleRequest(Request $request, SessionInterface $session): Result
+    public function handleRequest(Request $request, SessionInterface $session, CallContext $callContext): Result
     {
         switch ($request->method) {
             case 'initialize':
@@ -75,7 +75,7 @@ class Dispatcher
                 return $this->handleToolList($request);
             case 'tools/call':
                 $request = CallToolRequest::fromRequest($request);
-                return $this->handleToolCall($request);
+                return $this->handleToolCall($request, $callContext);
             case 'resources/list':
                 $request = ListResourcesRequest::fromRequest($request);
                 return $this->handleResourcesList($request);
@@ -151,7 +151,7 @@ class Dispatcher
         return new ListToolsResult(array_values($pagedItems), $nextCursor);
     }
 
-    public function handleToolCall(CallToolRequest $request): CallToolResult
+    public function handleToolCall(CallToolRequest $request, CallContext $callContext): CallToolResult
     {
         $toolName = $request->name;
         $arguments = $request->arguments;
@@ -184,7 +184,7 @@ class Dispatcher
         }
 
         try {
-            $result = $registeredTool->call($this->container, $arguments);
+            $result = $registeredTool->call($this->container, $arguments, $callContext);
 
             return new CallToolResult($result, false);
         } catch (JsonException $e) {

--- a/src/Elements/RegisteredElement.php
+++ b/src/Elements/RegisteredElement.php
@@ -31,7 +31,7 @@ class RegisteredElement implements JsonSerializable
         $this->isManual = $isManual;
     }
 
-    public function handle(ContainerInterface $container, array $arguments, ?Context $requestContext = null): mixed
+    public function handle(ContainerInterface $container, array $arguments, Context $requestContext): mixed
     {
         if (is_string($this->handler)) {
             if (class_exists($this->handler) && method_exists($this->handler, '__invoke')) {
@@ -67,7 +67,7 @@ class RegisteredElement implements JsonSerializable
     }
 
 
-    protected function prepareArguments(\ReflectionFunctionAbstract $reflection, array $arguments, ?Context $requestContext): array
+    protected function prepareArguments(\ReflectionFunctionAbstract $reflection, array $arguments, Context $requestContext): array
     {
         $finalArgs = [];
 
@@ -77,7 +77,7 @@ class RegisteredElement implements JsonSerializable
             $paramType = $parameter->getType();
             $paramPosition = $parameter->getPosition();
 
-            if ($paramType?->getName() === Context::class) {
+            if ($paramType instanceof ReflectionNamedType && $paramType->getName() === Context::class) {
                 $finalArgs[$paramPosition] = $requestContext;
 
                 continue;

--- a/src/Elements/RegisteredElement.php
+++ b/src/Elements/RegisteredElement.php
@@ -6,7 +6,7 @@ namespace PhpMcp\Server\Elements;
 
 use InvalidArgumentException;
 use JsonSerializable;
-use PhpMcp\Server\CallContext;
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Exception\McpServerException;
 use Psr\Container\ContainerInterface;
 use ReflectionException;
@@ -31,33 +31,33 @@ class RegisteredElement implements JsonSerializable
         $this->isManual = $isManual;
     }
 
-    public function handle(ContainerInterface $container, array $arguments, ?CallContext $callContext = null): mixed
+    public function handle(ContainerInterface $container, array $arguments, ?Context $requestContext = null): mixed
     {
         if (is_string($this->handler)) {
             if (class_exists($this->handler) && method_exists($this->handler, '__invoke')) {
                 $reflection = new \ReflectionMethod($this->handler, '__invoke');
-                $arguments = $this->prepareArguments($reflection, $arguments, $callContext);
+                $arguments = $this->prepareArguments($reflection, $arguments, $requestContext);
                 $instance = $container->get($this->handler);
                 return call_user_func($instance, ...$arguments);
             }
 
             if (function_exists($this->handler)) {
                 $reflection = new \ReflectionFunction($this->handler);
-                $arguments = $this->prepareArguments($reflection, $arguments, $callContext);
+                $arguments = $this->prepareArguments($reflection, $arguments, $requestContext);
                 return call_user_func($this->handler, ...$arguments);
             }
         }
 
         if (is_callable($this->handler)) {
             $reflection = $this->getReflectionForCallable($this->handler);
-            $arguments = $this->prepareArguments($reflection, $arguments, $callContext);
+            $arguments = $this->prepareArguments($reflection, $arguments, $requestContext);
             return call_user_func($this->handler, ...$arguments);
         }
 
         if (is_array($this->handler)) {
             [$className, $methodName] = $this->handler;
             $reflection = new \ReflectionMethod($className, $methodName);
-            $arguments = $this->prepareArguments($reflection, $arguments, $callContext);
+            $arguments = $this->prepareArguments($reflection, $arguments, $requestContext);
 
             $instance = $container->get($className);
             return call_user_func([$instance, $methodName], ...$arguments);
@@ -67,7 +67,7 @@ class RegisteredElement implements JsonSerializable
     }
 
 
-    protected function prepareArguments(\ReflectionFunctionAbstract $reflection, array $arguments, ?CallContext $callContext): array
+    protected function prepareArguments(\ReflectionFunctionAbstract $reflection, array $arguments, ?Context $requestContext): array
     {
         $finalArgs = [];
 
@@ -77,8 +77,8 @@ class RegisteredElement implements JsonSerializable
             $paramType = $parameter->getType();
             $paramPosition = $parameter->getPosition();
 
-            if ($paramType?->getName() === CallContext::class) {
-                $finalArgs[$paramPosition] = $callContext;
+            if ($paramType?->getName() === Context::class) {
+                $finalArgs[$paramPosition] = $requestContext;
 
                 continue;
             }

--- a/src/Elements/RegisteredPrompt.php
+++ b/src/Elements/RegisteredPrompt.php
@@ -44,9 +44,9 @@ class RegisteredPrompt extends RegisteredElement
      * @param  array  $arguments
      * @return PromptMessage[]
      */
-    public function get(ContainerInterface $container, array $arguments, Context $requestContext): array
+    public function get(ContainerInterface $container, array $arguments, Context $context): array
     {
-        $result = $this->handle($container, $arguments, $requestContext);
+        $result = $this->handle($container, $arguments, $context);
 
         return $this->formatResult($result);
     }

--- a/src/Elements/RegisteredPrompt.php
+++ b/src/Elements/RegisteredPrompt.php
@@ -15,6 +15,7 @@ use PhpMcp\Schema\Content\TextContent;
 use PhpMcp\Schema\Content\TextResourceContents;
 use PhpMcp\Schema\Enum\Role;
 use PhpMcp\Schema\Result\CompletionCompleteResult;
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Contracts\CompletionProviderInterface;
 use PhpMcp\Server\Contracts\SessionInterface;
 use Psr\Container\ContainerInterface;
@@ -43,9 +44,9 @@ class RegisteredPrompt extends RegisteredElement
      * @param  array  $arguments
      * @return PromptMessage[]
      */
-    public function get(ContainerInterface $container, array $arguments): array
+    public function get(ContainerInterface $container, array $arguments, Context $requestContext): array
     {
-        $result = $this->handle($container, $arguments);
+        $result = $this->handle($container, $arguments, $requestContext);
 
         return $this->formatResult($result);
     }

--- a/src/Elements/RegisteredResource.php
+++ b/src/Elements/RegisteredResource.php
@@ -9,6 +9,7 @@ use PhpMcp\Schema\Content\EmbeddedResource;
 use PhpMcp\Schema\Content\ResourceContents;
 use PhpMcp\Schema\Content\TextResourceContents;
 use PhpMcp\Schema\Resource;
+use PhpMcp\Server\Context;
 use Psr\Container\ContainerInterface;
 use Throwable;
 
@@ -32,9 +33,9 @@ class RegisteredResource extends RegisteredElement
      *
      * @return array<TextResourceContents|BlobResourceContents> Array of ResourceContents objects.
      */
-    public function read(ContainerInterface $container, string $uri): array
+    public function read(ContainerInterface $container, string $uri, Context $requestContext): array
     {
-        $result = $this->handle($container, ['uri' => $uri]);
+        $result = $this->handle($container, ['uri' => $uri], $requestContext);
 
         return $this->formatResult($result, $uri, $this->schema->mimeType);
     }

--- a/src/Elements/RegisteredResource.php
+++ b/src/Elements/RegisteredResource.php
@@ -33,9 +33,9 @@ class RegisteredResource extends RegisteredElement
      *
      * @return array<TextResourceContents|BlobResourceContents> Array of ResourceContents objects.
      */
-    public function read(ContainerInterface $container, string $uri, Context $requestContext): array
+    public function read(ContainerInterface $container, string $uri, Context $context): array
     {
-        $result = $this->handle($container, ['uri' => $uri], $requestContext);
+        $result = $this->handle($container, ['uri' => $uri], $context);
 
         return $this->formatResult($result, $uri, $this->schema->mimeType);
     }

--- a/src/Elements/RegisteredResourceTemplate.php
+++ b/src/Elements/RegisteredResourceTemplate.php
@@ -10,6 +10,7 @@ use PhpMcp\Schema\Content\ResourceContents;
 use PhpMcp\Schema\Content\TextResourceContents;
 use PhpMcp\Schema\ResourceTemplate;
 use PhpMcp\Schema\Result\CompletionCompleteResult;
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Contracts\SessionInterface;
 use Psr\Container\ContainerInterface;
 use Throwable;
@@ -41,11 +42,11 @@ class RegisteredResourceTemplate extends RegisteredElement
      *
      * @return array<TextResourceContents|BlobResourceContents> Array of ResourceContents objects.
      */
-    public function read(ContainerInterface $container, string $uri): array
+    public function read(ContainerInterface $container, string $uri, Context $requestContext): array
     {
         $arguments = array_merge($this->uriVariables, ['uri' => $uri]);
 
-        $result = $this->handle($container, $arguments);
+        $result = $this->handle($container, $arguments, $requestContext);
 
         return $this->formatResult($result, $uri, $this->schema->mimeType);
     }

--- a/src/Elements/RegisteredResourceTemplate.php
+++ b/src/Elements/RegisteredResourceTemplate.php
@@ -42,11 +42,11 @@ class RegisteredResourceTemplate extends RegisteredElement
      *
      * @return array<TextResourceContents|BlobResourceContents> Array of ResourceContents objects.
      */
-    public function read(ContainerInterface $container, string $uri, Context $requestContext): array
+    public function read(ContainerInterface $container, string $uri, Context $context): array
     {
         $arguments = array_merge($this->uriVariables, ['uri' => $uri]);
 
-        $result = $this->handle($container, $arguments, $requestContext);
+        $result = $this->handle($container, $arguments, $context);
 
         return $this->formatResult($result, $uri, $this->schema->mimeType);
     }

--- a/src/Elements/RegisteredTool.php
+++ b/src/Elements/RegisteredTool.php
@@ -6,6 +6,7 @@ namespace PhpMcp\Server\Elements;
 
 use PhpMcp\Schema\Content\Content;
 use PhpMcp\Schema\Content\TextContent;
+use PhpMcp\Server\CallContext;
 use Psr\Container\ContainerInterface;
 use PhpMcp\Schema\Tool;
 use Throwable;
@@ -30,9 +31,9 @@ class RegisteredTool extends RegisteredElement
      *
      * @return Content[] The content items for CallToolResult.
      */
-    public function call(ContainerInterface $container, array $arguments): array
+    public function call(ContainerInterface $container, array $arguments, CallContext $callContext): array
     {
-        $result = $this->handle($container, $arguments);
+        $result = $this->handle($container, $arguments, $callContext);
 
         return $this->formatResult($result);
     }

--- a/src/Elements/RegisteredTool.php
+++ b/src/Elements/RegisteredTool.php
@@ -6,7 +6,7 @@ namespace PhpMcp\Server\Elements;
 
 use PhpMcp\Schema\Content\Content;
 use PhpMcp\Schema\Content\TextContent;
-use PhpMcp\Server\CallContext;
+use PhpMcp\Server\Context;
 use Psr\Container\ContainerInterface;
 use PhpMcp\Schema\Tool;
 use Throwable;
@@ -31,9 +31,9 @@ class RegisteredTool extends RegisteredElement
      *
      * @return Content[] The content items for CallToolResult.
      */
-    public function call(ContainerInterface $container, array $arguments, CallContext $callContext): array
+    public function call(ContainerInterface $container, array $arguments, Context $requestContext): array
     {
-        $result = $this->handle($container, $arguments, $callContext);
+        $result = $this->handle($container, $arguments, $requestContext);
 
         return $this->formatResult($result);
     }

--- a/src/Elements/RegisteredTool.php
+++ b/src/Elements/RegisteredTool.php
@@ -31,9 +31,9 @@ class RegisteredTool extends RegisteredElement
      *
      * @return Content[] The content items for CallToolResult.
      */
-    public function call(ContainerInterface $container, array $arguments, Context $requestContext): array
+    public function call(ContainerInterface $container, array $arguments, Context $context): array
     {
-        $result = $this->handle($container, $arguments, $requestContext);
+        $result = $this->handle($container, $arguments, $context);
 
         return $this->formatResult($result);
     }

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -141,8 +141,8 @@ class Protocol
         }
 
         $requestContext = new Context(
-            $context['request'] ?? null,
             $session,
+            $context['request'] ?? null,
         );
 
         $response = null;

--- a/src/Transports/StreamableHttpServerTransport.php
+++ b/src/Transports/StreamableHttpServerTransport.php
@@ -367,6 +367,7 @@ class StreamableHttpServerTransport implements ServerTransportInterface, LoggerA
         }
 
         $context['stateless'] = $this->stateless;
+        $context['request'] = $request;
 
         $this->loop->futureTick(function () use ($message, $sessionId, $context) {
             $this->emit('message', [$message, $sessionId, $context]);

--- a/src/Utils/SchemaGenerator.php
+++ b/src/Utils/SchemaGenerator.php
@@ -4,7 +4,7 @@ namespace PhpMcp\Server\Utils;
 
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use PhpMcp\Server\Attributes\Schema;
-use PhpMcp\Server\CallContext;
+use PhpMcp\Server\Context;
 use ReflectionEnum;
 use ReflectionIntersectionType;
 use ReflectionMethod;
@@ -419,7 +419,7 @@ class SchemaGenerator
 
             $reflectionType = $rp->getType();
 
-            if ($reflectionType instanceof ReflectionNamedType && $reflectionType?->getName() === CallContext::class) {
+            if ($reflectionType instanceof ReflectionNamedType && $reflectionType?->getName() === Context::class) {
                 continue;
             }
 

--- a/src/Utils/SchemaGenerator.php
+++ b/src/Utils/SchemaGenerator.php
@@ -4,6 +4,7 @@ namespace PhpMcp\Server\Utils;
 
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use PhpMcp\Server\Attributes\Schema;
+use PhpMcp\Server\CallContext;
 use ReflectionEnum;
 use ReflectionIntersectionType;
 use ReflectionMethod;
@@ -417,6 +418,11 @@ class SchemaGenerator
             $paramTag = $paramTags['$' . $paramName] ?? null;
 
             $reflectionType = $rp->getType();
+
+            if ($reflectionType instanceof ReflectionNamedType && $reflectionType?->getName() === CallContext::class) {
+                continue;
+            }
+
             $typeString = $this->getParameterTypeString($rp, $paramTag);
             $description = $this->docBlockParser->getParamDescription($paramTag);
             $hasDefault = $rp->isDefaultValueAvailable();

--- a/tests/Fixtures/General/ToolHandlerFixture.php
+++ b/tests/Fixtures/General/ToolHandlerFixture.php
@@ -5,6 +5,7 @@ namespace PhpMcp\Server\Tests\Fixtures\General;
 use PhpMcp\Schema\Content\TextContent;
 use PhpMcp\Schema\Content\ImageContent;
 use PhpMcp\Schema\Content\AudioContent;
+use PhpMcp\Server\CallContext;
 use PhpMcp\Server\Tests\Fixtures\Enums\BackedStringEnum;
 use Psr\Log\LoggerInterface;
 
@@ -131,5 +132,14 @@ class ToolHandlerFixture
     public function toolUnencodableResult()
     {
         return fopen('php://memory', 'r');
+    }
+
+    public function toolReadsCallContext(CallContext $callContext): string
+    {
+        if (!$callContext->request) {
+            return "No request instance present";
+        }
+
+        return $callContext->request->getHeaderLine('X-Test-Header') ?: "No X-Test-Header";
     }
 }

--- a/tests/Fixtures/General/ToolHandlerFixture.php
+++ b/tests/Fixtures/General/ToolHandlerFixture.php
@@ -5,7 +5,7 @@ namespace PhpMcp\Server\Tests\Fixtures\General;
 use PhpMcp\Schema\Content\TextContent;
 use PhpMcp\Schema\Content\ImageContent;
 use PhpMcp\Schema\Content\AudioContent;
-use PhpMcp\Server\CallContext;
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Tests\Fixtures\Enums\BackedStringEnum;
 use Psr\Log\LoggerInterface;
 
@@ -134,12 +134,12 @@ class ToolHandlerFixture
         return fopen('php://memory', 'r');
     }
 
-    public function toolReadsCallContext(CallContext $callContext): string
+    public function toolReadsContext(Context $context): string
     {
-        if (!$callContext->request) {
+        if (!$context->request) {
             return "No request instance present";
         }
 
-        return $callContext->request->getHeaderLine('X-Test-Header') ?: "No X-Test-Header";
+        return $context->request->getHeaderLine('X-Test-Header') ?: "No X-Test-Header";
     }
 }

--- a/tests/Fixtures/General/VariousTypesHandler.php
+++ b/tests/Fixtures/General/VariousTypesHandler.php
@@ -2,6 +2,7 @@
 
 namespace PhpMcp\Server\Tests\Fixtures\General;
 
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Tests\Fixtures\Enums\BackedIntEnum;
 use PhpMcp\Server\Tests\Fixtures\Enums\BackedStringEnum;
 use PhpMcp\Server\Tests\Fixtures\Enums\UnitEnum;
@@ -141,5 +142,12 @@ class VariousTypesHandler
 
     public function methodCausesTypeError(int $mustBeInt): void
     {
+    }
+
+    public function contextArg(Context $context): array {
+        return [
+            'session' => $context->session->get('testKey'),
+            'request' => $context->request->getHeaderLine('testHeader'),
+        ];
     }
 }

--- a/tests/Fixtures/ServerScripts/StdioTestServer.php
+++ b/tests/Fixtures/ServerScripts/StdioTestServer.php
@@ -29,6 +29,7 @@ try {
         ->withServerInfo('StdioIntegrationTestServer', '0.1.0')
         ->withLogger($logger)
         ->withTool([ToolHandlerFixture::class, 'greet'], 'greet_stdio_tool')
+        ->withTool([ToolHandlerFixture::class, 'toolReadsCallContext'], 'tool_reads_call_context') // for CallContext testing
         ->withResource([ResourceHandlerFixture::class, 'getStaticText'], 'test://stdio/static', 'static_stdio_resource')
         ->withPrompt([PromptHandlerFixture::class, 'generateSimpleGreeting'], 'simple_stdio_prompt')
         ->build();

--- a/tests/Fixtures/ServerScripts/StdioTestServer.php
+++ b/tests/Fixtures/ServerScripts/StdioTestServer.php
@@ -29,7 +29,7 @@ try {
         ->withServerInfo('StdioIntegrationTestServer', '0.1.0')
         ->withLogger($logger)
         ->withTool([ToolHandlerFixture::class, 'greet'], 'greet_stdio_tool')
-        ->withTool([ToolHandlerFixture::class, 'toolReadsCallContext'], 'tool_reads_call_context') // for CallContext testing
+        ->withTool([ToolHandlerFixture::class, 'toolReadsContext'], 'tool_reads_context') // for Context testing
         ->withResource([ResourceHandlerFixture::class, 'getStaticText'], 'test://stdio/static', 'static_stdio_resource')
         ->withPrompt([PromptHandlerFixture::class, 'generateSimpleGreeting'], 'simple_stdio_prompt')
         ->build();

--- a/tests/Fixtures/ServerScripts/StreamableHttpTestServer.php
+++ b/tests/Fixtures/ServerScripts/StreamableHttpTestServer.php
@@ -40,7 +40,7 @@ try {
         ->withLogger($logger)
         ->withTool([ToolHandlerFixture::class, 'greet'], 'greet_streamable_tool')
         ->withTool([ToolHandlerFixture::class, 'sum'], 'sum_streamable_tool') // For batch testing
-        ->withTool([ToolHandlerFixture::class, 'toolReadsCallContext'], 'tool_reads_call_context') // for CallContext testing
+        ->withTool([ToolHandlerFixture::class, 'toolReadsContext'], 'tool_reads_context') // for Context testing
         ->withResource([ResourceHandlerFixture::class, 'getStaticText'], "test://streamable/static", 'static_streamable_resource')
         ->withPrompt([PromptHandlerFixture::class, 'generateSimpleGreeting'], 'simple_streamable_prompt')
         ->build();

--- a/tests/Fixtures/ServerScripts/StreamableHttpTestServer.php
+++ b/tests/Fixtures/ServerScripts/StreamableHttpTestServer.php
@@ -40,6 +40,7 @@ try {
         ->withLogger($logger)
         ->withTool([ToolHandlerFixture::class, 'greet'], 'greet_streamable_tool')
         ->withTool([ToolHandlerFixture::class, 'sum'], 'sum_streamable_tool') // For batch testing
+        ->withTool([ToolHandlerFixture::class, 'toolReadsCallContext'], 'tool_reads_call_context') // for CallContext testing
         ->withResource([ResourceHandlerFixture::class, 'getStaticText'], "test://streamable/static", 'static_streamable_resource')
         ->withPrompt([PromptHandlerFixture::class, 'generateSimpleGreeting'], 'simple_streamable_prompt')
         ->build();

--- a/tests/Fixtures/Utils/SchemaGeneratorFixture.php
+++ b/tests/Fixtures/Utils/SchemaGeneratorFixture.php
@@ -3,6 +3,7 @@
 namespace PhpMcp\Server\Tests\Fixtures\Utils;
 
 use PhpMcp\Server\Attributes\Schema;
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Tests\Fixtures\Enums\BackedIntEnum;
 use PhpMcp\Server\Tests\Fixtures\Enums\BackedStringEnum;
 use PhpMcp\Server\Tests\Fixtures\Enums\UnitEnum;
@@ -44,6 +45,10 @@ class SchemaGeneratorFixture
      * @param bool $verified Whether user is verified
      */
     public function typeHintsWithDocBlock(string $email, int $score, bool $verified): void
+    {
+    }
+
+    public function contextParameter(Context $context): void
     {
     }
 

--- a/tests/Integration/SchemaGenerationTest.php
+++ b/tests/Integration/SchemaGenerationTest.php
@@ -58,6 +58,16 @@ it('uses PHP type hints for type and DocBlock @param tags for descriptions when 
     expect($schema['required'])->toEqualCanonicalizing(['email', 'score', 'verified']);
 });
 
+it('ignores Context parameter for schema', function () {
+    $method = new ReflectionMethod(SchemaGeneratorFixture::class, 'contextParameter');
+    $schema = $this->schemaGenerator->generate($method);
+
+    expect($schema)->toEqual([
+        'type' => 'object',
+        'properties' => new stdClass()
+    ]);
+});
+
 it('uses the complete schema definition provided by a method-level #[Schema(definition: ...)] attribute', function () {
     $method = new ReflectionMethod(SchemaGeneratorFixture::class, 'methodLevelCompleteDefinition');
     $schema = $this->schemaGenerator->generate($method);

--- a/tests/Integration/StdioServerTransportTest.php
+++ b/tests/Integration/StdioServerTransportTest.php
@@ -241,19 +241,19 @@ it('can handle batch requests correctly', function () {
     $this->process->stdin->end();
 })->group('integration', 'stdio_transport');
 
-it('can passes an empty callcontext', function () {
-    sendRequestToServer($this->process, 'init-callcontext', 'initialize', ['protocolVersion' => Protocol::LATEST_PROTOCOL_VERSION, 'clientInfo' => [], 'capabilities' => []]);
-    await(readResponseFromServer($this->process, 'init-callcontext', $this->loop));
+it('can passes an empty context', function () {
+    sendRequestToServer($this->process, 'init-context', 'initialize', ['protocolVersion' => Protocol::LATEST_PROTOCOL_VERSION, 'clientInfo' => [], 'capabilities' => []]);
+    await(readResponseFromServer($this->process, 'init-context', $this->loop));
     sendNotificationToServer($this->process, 'notifications/initialized');
     await(delay(0.05, $this->loop));
 
-    sendRequestToServer($this->process, 'tool-callcontext-1', 'tools/call', [
-        'name' => 'tool_reads_call_context',
+    sendRequestToServer($this->process, 'tool-context-1', 'tools/call', [
+        'name' => 'tool_reads_context',
         'arguments' => []
     ]);
-    $toolResponse = await(readResponseFromServer($this->process, 'tool-callcontext-1', $this->loop));
+    $toolResponse = await(readResponseFromServer($this->process, 'tool-context-1', $this->loop));
 
-    expect($toolResponse['id'])->toBe('tool-callcontext-1');
+    expect($toolResponse['id'])->toBe('tool-context-1');
     expect($toolResponse)->not->toHaveKey('error');
     expect($toolResponse['result']['content'][0]['text'])->toBe('No request instance present');
     expect($toolResponse['result']['isError'])->toBeFalse();
@@ -274,7 +274,7 @@ it('can handle tool list request', function () {
     expect($toolListResponse)->not->toHaveKey('error');
     expect($toolListResponse['result']['tools'])->toBeArray()->toHaveCount(2);
     expect($toolListResponse['result']['tools'][0]['name'])->toBe('greet_stdio_tool');
-    expect($toolListResponse['result']['tools'][1]['name'])->toBe('tool_reads_call_context');
+    expect($toolListResponse['result']['tools'][1]['name'])->toBe('tool_reads_context');
 
     $this->process->stdin->end();
 })->group('integration', 'stdio_transport');

--- a/tests/Integration/StreamableHttpServerTransportTest.php
+++ b/tests/Integration/StreamableHttpServerTransportTest.php
@@ -220,24 +220,24 @@ describe('JSON MODE', function () {
         expect(count($toolListResult['body']['result']['tools']))->toBe(3);
         expect($toolListResult['body']['result']['tools'][0]['name'])->toBe('greet_streamable_tool');
         expect($toolListResult['body']['result']['tools'][1]['name'])->toBe('sum_streamable_tool');
-        expect($toolListResult['body']['result']['tools'][2]['name'])->toBe('tool_reads_call_context');
+        expect($toolListResult['body']['result']['tools'][2]['name'])->toBe('tool_reads_context');
     })->group('integration', 'streamable_http_json');
 
-    it('passes request in CallContext', function () {
+    it('passes request in Context', function () {
         await($this->jsonClient->sendRequest('initialize', [
             'protocolVersion' => Protocol::LATEST_PROTOCOL_VERSION,
             'clientInfo' => ['name' => 'JsonModeClient', 'version' => '1.0'],
             'capabilities' => []
-        ], 'init-json-callcontext'));
+        ], 'init-json-context'));
         await($this->jsonClient->sendNotification('notifications/initialized'));
 
         $toolResult = await($this->jsonClient->sendRequest('tools/call', [
-            'name' => 'tool_reads_call_context',
+            'name' => 'tool_reads_context',
             'arguments' => []
-        ], 'tool-json-callcontext-1', ['X-Test-Header' => 'TestValue']));
+        ], 'tool-json-context-1', ['X-Test-Header' => 'TestValue']));
 
         expect($toolResult['statusCode'])->toBe(200);
-        expect($toolResult['body']['id'])->toBe('tool-json-callcontext-1');
+        expect($toolResult['body']['id'])->toBe('tool-json-context-1');
         expect($toolResult['body'])->not->toHaveKey('error');
         expect($toolResult['body']['result']['content'][0]['text'])->toBe('TestValue');
     })->group('integration', 'streamable_http_json');
@@ -432,21 +432,21 @@ describe('STREAM MODE', function () {
         expect($response3['error']['message'])->toContain("Method 'nonexistent/method' not found");
     })->group('integration', 'streamable_http_stream');
 
-    it('passes request in CallContext', function () {
+    it('passes request in Context', function () {
         await($this->streamClient->sendInitializeRequest([
             'protocolVersion' => Protocol::LATEST_PROTOCOL_VERSION,
             'clientInfo' => ['name' => 'StreamModeClient', 'version' => '1.0'],
             'capabilities' => []
-        ], 'init-stream-callcontext'));
+        ], 'init-stream-context'));
         expect($this->streamClient->sessionId)->toBeString()->not->toBeEmpty();
         await($this->streamClient->sendHttpNotification('notifications/initialized'));
 
         $toolResult = await($this->streamClient->sendRequest('tools/call', [
-            'name' => 'tool_reads_call_context',
+            'name' => 'tool_reads_context',
             'arguments' => []
-        ], 'tool-stream-callcontext-1', ['X-Test-Header' => 'TestValue']));
+        ], 'tool-stream-context-1', ['X-Test-Header' => 'TestValue']));
 
-        expect($toolResult['id'])->toBe('tool-stream-callcontext-1');
+        expect($toolResult['id'])->toBe('tool-stream-context-1');
         expect($toolResult)->not->toHaveKey('error');
         expect($toolResult['result']['content'][0]['text'])->toBe('TestValue');
     })->group('integration', 'streamable_http_stream');
@@ -463,7 +463,7 @@ describe('STREAM MODE', function () {
         expect(count($toolListResponse['result']['tools']))->toBe(3);
         expect($toolListResponse['result']['tools'][0]['name'])->toBe('greet_streamable_tool');
         expect($toolListResponse['result']['tools'][1]['name'])->toBe('sum_streamable_tool');
-        expect($toolListResponse['result']['tools'][2]['name'])->toBe('tool_reads_call_context');
+        expect($toolListResponse['result']['tools'][2]['name'])->toBe('tool_reads_context');
     })->group('integration', 'streamable_http_stream');
 
     it('can read a registered resource', function () {
@@ -644,14 +644,14 @@ describe('STATELESS MODE', function () {
         expect($response3['error']['message'])->toContain("Method 'nonexistent/method' not found");
     })->group('integration', 'streamable_http_stateless');
 
-    it('passes request in CallContext', function () {
+    it('passes request in Context', function () {
         $toolResult = await($this->statelessClient->sendRequest('tools/call', [
-            'name' => 'tool_reads_call_context',
+            'name' => 'tool_reads_context',
             'arguments' => []
-        ], 'tool-stateless-callcontext-1', ['X-Test-Header' => 'TestValue']));
+        ], 'tool-stateless-context-1', ['X-Test-Header' => 'TestValue']));
 
         expect($toolResult['statusCode'])->toBe(200);
-        expect($toolResult['body']['id'])->toBe('tool-stateless-callcontext-1');
+        expect($toolResult['body']['id'])->toBe('tool-stateless-context-1');
         expect($toolResult['body'])->not->toHaveKey('error');
         expect($toolResult['body']['result']['content'][0]['text'])->toBe('TestValue');
     })->group('integration', 'streamable_http_stateless');
@@ -666,7 +666,7 @@ describe('STATELESS MODE', function () {
         expect(count($toolListResult['body']['result']['tools']))->toBe(3);
         expect($toolListResult['body']['result']['tools'][0]['name'])->toBe('greet_streamable_tool');
         expect($toolListResult['body']['result']['tools'][1]['name'])->toBe('sum_streamable_tool');
-        expect($toolListResult['body']['result']['tools'][2]['name'])->toBe('tool_reads_call_context');
+        expect($toolListResult['body']['result']['tools'][2]['name'])->toBe('tool_reads_context');
     })->group('integration', 'streamable_http_stateless');
 
     it('can read a registered resource', function () {

--- a/tests/Integration/StreamableHttpServerTransportTest.php
+++ b/tests/Integration/StreamableHttpServerTransportTest.php
@@ -217,9 +217,29 @@ describe('JSON MODE', function () {
         expect($toolListResult['statusCode'])->toBe(200);
         expect($toolListResult['body']['id'])->toBe('tool-list-json-1');
         expect($toolListResult['body']['result']['tools'])->toBeArray();
-        expect(count($toolListResult['body']['result']['tools']))->toBe(2);
+        expect(count($toolListResult['body']['result']['tools']))->toBe(3);
         expect($toolListResult['body']['result']['tools'][0]['name'])->toBe('greet_streamable_tool');
         expect($toolListResult['body']['result']['tools'][1]['name'])->toBe('sum_streamable_tool');
+        expect($toolListResult['body']['result']['tools'][2]['name'])->toBe('tool_reads_call_context');
+    })->group('integration', 'streamable_http_json');
+
+    it('passes request in CallContext', function () {
+        await($this->jsonClient->sendRequest('initialize', [
+            'protocolVersion' => Protocol::LATEST_PROTOCOL_VERSION,
+            'clientInfo' => ['name' => 'JsonModeClient', 'version' => '1.0'],
+            'capabilities' => []
+        ], 'init-json-callcontext'));
+        await($this->jsonClient->sendNotification('notifications/initialized'));
+
+        $toolResult = await($this->jsonClient->sendRequest('tools/call', [
+            'name' => 'tool_reads_call_context',
+            'arguments' => []
+        ], 'tool-json-callcontext-1', ['X-Test-Header' => 'TestValue']));
+
+        expect($toolResult['statusCode'])->toBe(200);
+        expect($toolResult['body']['id'])->toBe('tool-json-callcontext-1');
+        expect($toolResult['body'])->not->toHaveKey('error');
+        expect($toolResult['body']['result']['content'][0]['text'])->toBe('TestValue');
     })->group('integration', 'streamable_http_json');
 
     it('can read a registered resource', function () {
@@ -412,6 +432,25 @@ describe('STREAM MODE', function () {
         expect($response3['error']['message'])->toContain("Method 'nonexistent/method' not found");
     })->group('integration', 'streamable_http_stream');
 
+    it('passes request in CallContext', function () {
+        await($this->streamClient->sendInitializeRequest([
+            'protocolVersion' => Protocol::LATEST_PROTOCOL_VERSION,
+            'clientInfo' => ['name' => 'StreamModeClient', 'version' => '1.0'],
+            'capabilities' => []
+        ], 'init-stream-callcontext'));
+        expect($this->streamClient->sessionId)->toBeString()->not->toBeEmpty();
+        await($this->streamClient->sendHttpNotification('notifications/initialized'));
+
+        $toolResult = await($this->streamClient->sendRequest('tools/call', [
+            'name' => 'tool_reads_call_context',
+            'arguments' => []
+        ], 'tool-stream-callcontext-1', ['X-Test-Header' => 'TestValue']));
+
+        expect($toolResult['id'])->toBe('tool-stream-callcontext-1');
+        expect($toolResult)->not->toHaveKey('error');
+        expect($toolResult['result']['content'][0]['text'])->toBe('TestValue');
+    })->group('integration', 'streamable_http_stream');
+
     it('can handle tool list request', function () {
         await($this->streamClient->sendInitializeRequest(['protocolVersion' => Protocol::LATEST_PROTOCOL_VERSION, 'clientInfo' => []], 'init-stream-tools'));
         await($this->streamClient->sendHttpNotification('notifications/initialized'));
@@ -421,9 +460,10 @@ describe('STREAM MODE', function () {
         expect($toolListResponse['id'])->toBe('tool-list-stream-1');
         expect($toolListResponse)->not->toHaveKey('error');
         expect($toolListResponse['result']['tools'])->toBeArray();
-        expect(count($toolListResponse['result']['tools']))->toBe(2);
+        expect(count($toolListResponse['result']['tools']))->toBe(3);
         expect($toolListResponse['result']['tools'][0]['name'])->toBe('greet_streamable_tool');
         expect($toolListResponse['result']['tools'][1]['name'])->toBe('sum_streamable_tool');
+        expect($toolListResponse['result']['tools'][2]['name'])->toBe('tool_reads_call_context');
     })->group('integration', 'streamable_http_stream');
 
     it('can read a registered resource', function () {
@@ -604,6 +644,18 @@ describe('STATELESS MODE', function () {
         expect($response3['error']['message'])->toContain("Method 'nonexistent/method' not found");
     })->group('integration', 'streamable_http_stateless');
 
+    it('passes request in CallContext', function () {
+        $toolResult = await($this->statelessClient->sendRequest('tools/call', [
+            'name' => 'tool_reads_call_context',
+            'arguments' => []
+        ], 'tool-stateless-callcontext-1', ['X-Test-Header' => 'TestValue']));
+
+        expect($toolResult['statusCode'])->toBe(200);
+        expect($toolResult['body']['id'])->toBe('tool-stateless-callcontext-1');
+        expect($toolResult['body'])->not->toHaveKey('error');
+        expect($toolResult['body']['result']['content'][0]['text'])->toBe('TestValue');
+    })->group('integration', 'streamable_http_stateless');
+
     it('can handle tool list request', function () {
         $toolListResult = await($this->statelessClient->sendRequest('tools/list', [], 'tool-list-stateless-1'));
 
@@ -611,9 +663,10 @@ describe('STATELESS MODE', function () {
         expect($toolListResult['body']['id'])->toBe('tool-list-stateless-1');
         expect($toolListResult['body'])->not->toHaveKey('error');
         expect($toolListResult['body']['result']['tools'])->toBeArray();
-        expect(count($toolListResult['body']['result']['tools']))->toBe(2);
+        expect(count($toolListResult['body']['result']['tools']))->toBe(3);
         expect($toolListResult['body']['result']['tools'][0]['name'])->toBe('greet_streamable_tool');
         expect($toolListResult['body']['result']['tools'][1]['name'])->toBe('sum_streamable_tool');
+        expect($toolListResult['body']['result']['tools'][2]['name'])->toBe('tool_reads_call_context');
     })->group('integration', 'streamable_http_stateless');
 
     it('can read a registered resource', function () {

--- a/tests/Mocks/Clients/MockJsonHttpClient.php
+++ b/tests/Mocks/Clients/MockJsonHttpClient.php
@@ -20,7 +20,7 @@ class MockJsonHttpClient
         $this->baseUrl = "http://{$host}:{$port}/{$mcpPath}";
     }
 
-    public function sendRequest(string $method, array $params = [], ?string $id = null): PromiseInterface
+    public function sendRequest(string $method, array $params = [], ?string $id = null, array $additionalHeaders = []): PromiseInterface
     {
         $payload = ['jsonrpc' => '2.0', 'method' => $method, 'params' => $params];
         if ($id !== null) {
@@ -31,6 +31,7 @@ class MockJsonHttpClient
         if ($this->sessionId && $method !== 'initialize') {
             $headers['Mcp-Session-Id'] = $this->sessionId;
         }
+        $headers += $additionalHeaders;
 
         $body = json_encode($payload);
 

--- a/tests/Mocks/Clients/MockStreamHttpClient.php
+++ b/tests/Mocks/Clients/MockStreamHttpClient.php
@@ -103,11 +103,14 @@ class MockStreamHttpClient
             });
     }
 
-    public function sendRequest(string $method, array $params, string $id): PromiseInterface
+    public function sendRequest(string $method, array $params, string $id, array $additionalHeaders = []): PromiseInterface
     {
         $payload = ['jsonrpc' => '2.0', 'method' => $method, 'params' => $params, 'id' => $id];
         $headers = ['Content-Type' => 'application/json', 'Accept' => 'text/event-stream'];
-        if ($this->sessionId) $headers['Mcp-Session-Id'] = $this->sessionId;
+        if ($this->sessionId) {
+            $headers['Mcp-Session-Id'] = $this->sessionId;
+        }
+        $headers += $additionalHeaders;
 
         $body = json_encode($payload);
 

--- a/tests/Unit/DispatcherTest.php
+++ b/tests/Unit/DispatcherTest.php
@@ -72,7 +72,7 @@ beforeEach(function () {
     $this->session = Mockery::mock(SessionInterface::class);
     /** @var MockInterface&ContainerInterface $container */
     $this->container = Mockery::mock(ContainerInterface::class);
-    $this->context = new Context(Mockery::mock(SessionInterface::class));
+    $this->context = new Context($this->session);
 
     $configuration = new Configuration(
         serverInfo: Implementation::make('DispatcherTestServer', '1.0'),
@@ -106,7 +106,7 @@ it('routes to handleInitialize for initialize request', function () {
     $this->session->shouldReceive('set')->with('client_info', Mockery::on(fn($value) => $value['name'] === 'client' && $value['version'] === '1.0'))->once();
     $this->session->shouldReceive('set')->with('protocol_version', Protocol::LATEST_PROTOCOL_VERSION)->once();
 
-    $result = $this->dispatcher->handleRequest($request, $this->session, $this->context);
+    $result = $this->dispatcher->handleRequest($request, $this->context);
     expect($result)->toBeInstanceOf(InitializeResult::class);
     expect($result->protocolVersion)->toBe(Protocol::LATEST_PROTOCOL_VERSION);
     expect($result->serverInfo->name)->toBe('DispatcherTestServer');
@@ -114,13 +114,13 @@ it('routes to handleInitialize for initialize request', function () {
 
 it('routes to handlePing for ping request', function () {
     $request = new JsonRpcRequest('2.0', 'id1', 'ping', []);
-    $result = $this->dispatcher->handleRequest($request, $this->session, $this->context);
+    $result = $this->dispatcher->handleRequest($request, $this->context);
     expect($result)->toBeInstanceOf(EmptyResult::class);
 });
 
 it('throws MethodNotFound for unknown request method', function () {
     $rawRequest = new JsonRpcRequest('2.0', 'id1', 'unknown/method', []);
-    $this->dispatcher->handleRequest($rawRequest, $this->session, $this->context);
+    $this->dispatcher->handleRequest($rawRequest, $this->context);
 })->throws(McpServerException::class, "Method 'unknown/method' not found.");
 
 it('routes to handleNotificationInitialized for initialized notification', function () {

--- a/tests/Unit/DispatcherTest.php
+++ b/tests/Unit/DispatcherTest.php
@@ -6,7 +6,7 @@ use Grpc\Call;
 use Mockery;
 use Mockery\MockInterface;
 use PhpMcp\Schema\ClientCapabilities;
-use PhpMcp\Server\CallContext;
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Configuration;
 use PhpMcp\Server\Contracts\CompletionProviderInterface;
 use PhpMcp\Server\Contracts\SessionInterface;
@@ -106,7 +106,7 @@ it('routes to handleInitialize for initialize request', function () {
     $this->session->shouldReceive('set')->with('client_info', Mockery::on(fn($value) => $value['name'] === 'client' && $value['version'] === '1.0'))->once();
     $this->session->shouldReceive('set')->with('protocol_version', Protocol::LATEST_PROTOCOL_VERSION)->once();
 
-    $result = $this->dispatcher->handleRequest($request, $this->session, new CallContext());
+    $result = $this->dispatcher->handleRequest($request, $this->session, new Context(null, Mockery::mock(SessionInterface::class)));
     expect($result)->toBeInstanceOf(InitializeResult::class);
     expect($result->protocolVersion)->toBe(Protocol::LATEST_PROTOCOL_VERSION);
     expect($result->serverInfo->name)->toBe('DispatcherTestServer');
@@ -114,13 +114,13 @@ it('routes to handleInitialize for initialize request', function () {
 
 it('routes to handlePing for ping request', function () {
     $request = new JsonRpcRequest('2.0', 'id1', 'ping', []);
-    $result = $this->dispatcher->handleRequest($request, $this->session, new CallContext());
+    $result = $this->dispatcher->handleRequest($request, $this->session, new Context(null, Mockery::mock(SessionInterface::class)));
     expect($result)->toBeInstanceOf(EmptyResult::class);
 });
 
 it('throws MethodNotFound for unknown request method', function () {
     $rawRequest = new JsonRpcRequest('2.0', 'id1', 'unknown/method', []);
-    $this->dispatcher->handleRequest($rawRequest, $this->session, new CallContext());
+    $this->dispatcher->handleRequest($rawRequest, $this->session, new Context(null, Mockery::mock(SessionInterface::class)));
 })->throws(McpServerException::class, "Method 'unknown/method' not found.");
 
 it('routes to handleNotificationInitialized for initialized notification', function () {
@@ -202,14 +202,14 @@ it('can handle tool call request and return result', function () {
     $args = ['a' => 10, 'b' => 5];
     $toolSchema = ToolSchema::make($toolName, ['type' => 'object', 'properties' => ['a' => ['type' => 'integer'], 'b' => ['type' => 'integer']]]);
     $registeredToolMock = Mockery::mock(RegisteredTool::class, [$toolSchema, 'MyToolHandler', 'handleTool', false]);
-    $callContext = new CallContext();
+    $context = new Context(null, Mockery::mock(SessionInterface::class));
 
     $this->registry->shouldReceive('getTool')->with($toolName)->andReturn($registeredToolMock);
     $this->schemaValidator->shouldReceive('validateAgainstJsonSchema')->with($args, $toolSchema->inputSchema)->andReturn([]); // No validation errors
-    $registeredToolMock->shouldReceive('call')->with($this->container, $args, $callContext)->andReturn([TextContent::make("Result: 15")]);
+    $registeredToolMock->shouldReceive('call')->with($this->container, $args, $context)->andReturn([TextContent::make("Result: 15")]);
 
     $request = CallToolRequest::make(1, $toolName, $args);
-    $result = $this->dispatcher->handleToolCall($request, $callContext);
+    $result = $this->dispatcher->handleToolCall($request, $context);
 
     expect($result)->toBeInstanceOf(CallToolResult::class);
     expect($result->content[0]->text)->toBe("Result: 15");
@@ -219,7 +219,7 @@ it('can handle tool call request and return result', function () {
 it('can handle tool call request and throw exception if tool not found', function () {
     $this->registry->shouldReceive('getTool')->with('unknown-tool')->andReturn(null);
     $request = CallToolRequest::make(1, 'unknown-tool', []);
-    $this->dispatcher->handleToolCall($request, new CallContext());
+    $this->dispatcher->handleToolCall($request, new Context(null, Mockery::mock(SessionInterface::class)));
 })->throws(McpServerException::class, "Tool 'unknown-tool' not found.");
 
 it('can handle tool call request and throw exception if argument validation fails', function () {
@@ -234,7 +234,7 @@ it('can handle tool call request and throw exception if argument validation fail
 
     $request = CallToolRequest::make(1, $toolName, $args);
     try {
-        $this->dispatcher->handleToolCall($request, new CallContext());
+        $this->dispatcher->handleToolCall($request, new Context(null, Mockery::mock(SessionInterface::class)));
     } catch (McpServerException $e) {
         expect($e->getMessage())->toContain("Invalid parameters for tool 'strict-tool'");
         expect($e->getData()['validation_errors'])->toBeArray();
@@ -251,7 +251,7 @@ it('can handle tool call request and return error if tool execution throws excep
     $registeredToolMock->shouldReceive('call')->andThrow(new \RuntimeException("Tool crashed!"));
 
     $request = CallToolRequest::make(1, $toolName, []);
-    $result = $this->dispatcher->handleToolCall($request, new CallContext());
+    $result = $this->dispatcher->handleToolCall($request, new Context(null, Mockery::mock(SessionInterface::class)));
 
     expect($result->isError)->toBeTrue();
     expect($result->content[0]->text)->toBe("Tool execution failed: Tool crashed!");
@@ -268,7 +268,7 @@ it('can handle tool call request and return error if result formatting fails', f
 
 
     $request = CallToolRequest::make(1, $toolName, []);
-    $result = $this->dispatcher->handleToolCall($request, new CallContext());
+    $result = $this->dispatcher->handleToolCall($request, new Context(null, Mockery::mock(SessionInterface::class)));
 
     expect($result->isError)->toBeTrue();
     expect($result->content[0]->text)->toBe("Failed to serialize tool result: Unencodable.");

--- a/tests/Unit/Elements/RegisteredToolTest.php
+++ b/tests/Unit/Elements/RegisteredToolTest.php
@@ -6,7 +6,8 @@ use InvalidArgumentException;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PhpMcp\Schema\Tool;
-use PhpMcp\Server\CallContext;
+use PhpMcp\Server\Context;
+use PhpMcp\Server\Contracts\SessionInterface;
 use PhpMcp\Server\Elements\RegisteredTool;
 use PhpMcp\Schema\Content\TextContent;
 use PhpMcp\Schema\Content\ImageContent;
@@ -54,7 +55,7 @@ it('calls the handler with prepared arguments', function () {
     $mockHandler->shouldReceive('sum')->with(5, 10)->once()->andReturn(15);
     $this->container->shouldReceive('get')->with(ToolHandlerFixture::class)->andReturn($mockHandler);
 
-    $resultContents = $tool->call($this->container, ['a' => 5, 'b' => '10'], new CallContext()); // '10' will be cast to int by prepareArguments
+    $resultContents = $tool->call($this->container, ['a' => 5, 'b' => '10'], new Context(null, Mockery::mock(SessionInterface::class))); // '10' will be cast to int by prepareArguments
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe('15');
@@ -69,7 +70,7 @@ it('calls handler with no arguments if tool takes none and none provided', funct
     $mockHandler->shouldReceive('noParamsTool')->withNoArgs()->once()->andReturn(['status' => 'done']);
     $this->container->shouldReceive('get')->with(ToolHandlerFixture::class)->andReturn($mockHandler);
 
-    $resultContents = $tool->call($this->container, [], new CallContext());
+    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe(json_encode(['status' => 'done'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
 });
 
@@ -91,7 +92,7 @@ it('formats various scalar and simple object/array handler results into TextCont
         [ToolHandlerFixture::class, $handlerMethod]
     );
 
-    $resultContents = $tool->call($this->container, [], new CallContext());
+    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe($expectedText);
@@ -102,7 +103,7 @@ it('returns single Content object from handler as array with one Content object'
         Tool::make('content-test-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnTextContent']
     );
-    $resultContents = $tool->call($this->container, [], new CallContext());
+    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe("Pre-formatted TextContent.");
@@ -113,7 +114,7 @@ it('returns array of Content objects from handler as is', function () {
         Tool::make('content-array-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnArrayOfContent']
     );
-    $resultContents = $tool->call($this->container, [], new CallContext());
+    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
 
     expect($resultContents)->toBeArray()->toHaveCount(2);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe("Part 1");
@@ -125,7 +126,7 @@ it('formats mixed array from handler into array of Content objects', function ()
         Tool::make('mixed-array-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnMixedArray']
     );
-    $resultContents = $tool->call($this->container, [], new CallContext());
+    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
 
     expect($resultContents)->toBeArray()->toHaveCount(8);
 
@@ -144,7 +145,7 @@ it('formats empty array from handler into TextContent with "[]"', function () {
         Tool::make('empty-array-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnEmptyArray']
     );
-    $resultContents = $tool->call($this->container, [], new CallContext());
+    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe('[]');
@@ -155,7 +156,7 @@ it('throws JsonException during formatResult if handler returns unencodable valu
         Tool::make('unencodable-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'toolUnencodableResult']
     );
-    $tool->call($this->container, [], new CallContext());
+    $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
 })->throws(JsonException::class);
 
 it('re-throws exceptions from handler execution wrapped in McpServerException from handle()', function () {
@@ -166,5 +167,5 @@ it('re-throws exceptions from handler execution wrapped in McpServerException fr
 
     $this->container->shouldReceive('get')->with(ToolHandlerFixture::class)->once()->andReturn(new ToolHandlerFixture());
 
-    $tool->call($this->container, [], new CallContext());
+    $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
 })->throws(InvalidArgumentException::class, "Something went wrong in the tool.");

--- a/tests/Unit/Elements/RegisteredToolTest.php
+++ b/tests/Unit/Elements/RegisteredToolTest.php
@@ -33,6 +33,7 @@ beforeEach(function () {
         $this->toolSchema,
         [ToolHandlerFixture::class, 'greet']
     );
+    $this->context = new Context(Mockery::mock(SessionInterface::class));
 });
 
 it('constructs correctly and exposes schema', function () {
@@ -55,7 +56,7 @@ it('calls the handler with prepared arguments', function () {
     $mockHandler->shouldReceive('sum')->with(5, 10)->once()->andReturn(15);
     $this->container->shouldReceive('get')->with(ToolHandlerFixture::class)->andReturn($mockHandler);
 
-    $resultContents = $tool->call($this->container, ['a' => 5, 'b' => '10'], new Context(null, Mockery::mock(SessionInterface::class))); // '10' will be cast to int by prepareArguments
+    $resultContents = $tool->call($this->container, ['a' => 5, 'b' => '10'], $this->context); // '10' will be cast to int by prepareArguments
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe('15');
@@ -70,7 +71,7 @@ it('calls handler with no arguments if tool takes none and none provided', funct
     $mockHandler->shouldReceive('noParamsTool')->withNoArgs()->once()->andReturn(['status' => 'done']);
     $this->container->shouldReceive('get')->with(ToolHandlerFixture::class)->andReturn($mockHandler);
 
-    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $resultContents = $tool->call($this->container, [], $this->context);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe(json_encode(['status' => 'done'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
 });
 
@@ -92,7 +93,7 @@ it('formats various scalar and simple object/array handler results into TextCont
         [ToolHandlerFixture::class, $handlerMethod]
     );
 
-    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $resultContents = $tool->call($this->container, [], $this->context);
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe($expectedText);
@@ -103,7 +104,7 @@ it('returns single Content object from handler as array with one Content object'
         Tool::make('content-test-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnTextContent']
     );
-    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $resultContents = $tool->call($this->container, [], $this->context);
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe("Pre-formatted TextContent.");
@@ -114,7 +115,7 @@ it('returns array of Content objects from handler as is', function () {
         Tool::make('content-array-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnArrayOfContent']
     );
-    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $resultContents = $tool->call($this->container, [], $this->context);
 
     expect($resultContents)->toBeArray()->toHaveCount(2);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe("Part 1");
@@ -126,7 +127,7 @@ it('formats mixed array from handler into array of Content objects', function ()
         Tool::make('mixed-array-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnMixedArray']
     );
-    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $resultContents = $tool->call($this->container, [], $this->context);
 
     expect($resultContents)->toBeArray()->toHaveCount(8);
 
@@ -145,7 +146,7 @@ it('formats empty array from handler into TextContent with "[]"', function () {
         Tool::make('empty-array-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'returnEmptyArray']
     );
-    $resultContents = $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $resultContents = $tool->call($this->container, [], $this->context);
 
     expect($resultContents)->toBeArray()->toHaveCount(1);
     expect($resultContents[0])->toBeInstanceOf(TextContent::class)->text->toBe('[]');
@@ -156,7 +157,7 @@ it('throws JsonException during formatResult if handler returns unencodable valu
         Tool::make('unencodable-tool', ['type' => 'object', 'properties' => []]),
         [ToolHandlerFixture::class, 'toolUnencodableResult']
     );
-    $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $tool->call($this->container, [], $this->context);
 })->throws(JsonException::class);
 
 it('re-throws exceptions from handler execution wrapped in McpServerException from handle()', function () {
@@ -167,5 +168,5 @@ it('re-throws exceptions from handler execution wrapped in McpServerException fr
 
     $this->container->shouldReceive('get')->with(ToolHandlerFixture::class)->once()->andReturn(new ToolHandlerFixture());
 
-    $tool->call($this->container, [], new Context(null, Mockery::mock(SessionInterface::class)));
+    $tool->call($this->container, [], $this->context);
 })->throws(InvalidArgumentException::class, "Something went wrong in the tool.");

--- a/tests/Unit/ProtocolTest.php
+++ b/tests/Unit/ProtocolTest.php
@@ -5,7 +5,7 @@ namespace PhpMcp\Server\Tests\Unit;
 use Mockery;
 use Mockery\MockInterface;
 use PhpMcp\Schema\Implementation;
-use PhpMcp\Server\CallContext;
+use PhpMcp\Server\Context;
 use PhpMcp\Server\Configuration;
 use PhpMcp\Server\Contracts\ServerTransportInterface;
 use PhpMcp\Server\Dispatcher;
@@ -175,7 +175,7 @@ it('processes a valid Request message', function () {
         ->with(
             Mockery::on(fn ($arg) => $arg instanceof Request && $arg->method === 'test/method'),
             $this->session,
-            Mockery::type(CallContext::class)
+            Mockery::type(Context::class)
         )
         ->andReturn($result);
 
@@ -209,9 +209,9 @@ it('processes a BatchRequest with mixed requests and notifications', function ()
     $result1 = new EmptyResult();
     $result2 = new EmptyResult();
 
-    $this->dispatcher->shouldReceive('handleRequest')->once()->with(Mockery::on(fn (Request $r) => $r->id === 'batch-id-1'), $this->session, Mockery::type(CallContext::class))->andReturn($result1);
+    $this->dispatcher->shouldReceive('handleRequest')->once()->with(Mockery::on(fn (Request $r) => $r->id === 'batch-id-1'), $this->session, Mockery::type(Context::class))->andReturn($result1);
     $this->dispatcher->shouldReceive('handleNotification')->once()->with(Mockery::on(fn (Notification $n) => $n->method === 'notif/1'), $this->session);
-    $this->dispatcher->shouldReceive('handleRequest')->once()->with(Mockery::on(fn (Request $r) => $r->id === 'batch-id-2'), $this->session, Mockery::type(CallContext::class))->andReturn($result2);
+    $this->dispatcher->shouldReceive('handleRequest')->once()->with(Mockery::on(fn (Request $r) => $r->id === 'batch-id-2'), $this->session, Mockery::type(Context::class))->andReturn($result2);
 
 
     $this->transport->shouldReceive('sendMessage')->once()
@@ -502,7 +502,7 @@ it('allows initialize request when session not initialized', function () {
     $this->session->shouldReceive('get')->with('initialized', false)->andReturn(false);
 
     $this->dispatcher->shouldReceive('handleRequest')->once()
-        ->with(Mockery::type(Request::class), $this->session, Mockery::type(CallContext::class))
+        ->with(Mockery::type(Request::class), $this->session, Mockery::type(Context::class))
         ->andReturn(new EmptyResult());
 
     $this->transport->shouldReceive('sendMessage')->once()


### PR DESCRIPTION
## Requirement

In the context of the MCP Tool execution I would need access to the `Authorization` header being sent with the HTTP request.
My MCP Tool will further facilitate an SDK/API for which the authentication data is required.

## Implementation

- Introduced a `CallContext` object, which can hold also further properties in future
- The `CallContext` property on MCP Tool methods is not exposed in the MCP protocol (see `Discovery`)
- The `CallContext` instance is automatically passed to the method invocation if present in method signature

Remarks:
- I have no strong feelings regarding the naming, please suggest any better names if appropriate
- Side notes:
  - there's no `.php-cs-fixer.php` config file in the repo, but it is defined in the `composer lint` command 🤷 

## Open Todos
- [x] Tests for the parameter discovery

(Please let me know your thoughts, then I will continue with the missing tests)

## Example

```php
#[McpTool(name: 'my_tool')]
public function thisIsMyTool(string $anyParam, CallContext $callContext): array
{
    $authHeader = $callContext->request?->getHeaderLine('Authorization') ?: null;
    // use $authHeader here in your own logic
}
```

