### PR TITLE
Fix parameter-level schema output by returning raw definition

### DIFF
--- a/src/Utils/SchemaGenerator.php
+++ b/src/Utils/SchemaGenerator.php
@@ -183,6 +183,10 @@ class SchemaGenerator
         // Parameter-level takes highest precedence
         $parameterLevelSchema = $paramInfo['parameter_schema'];
         if (!empty($parameterLevelSchema)) {
+            if (isset($parameterLevelSchema['definition']) && is_array($parameterLevelSchema['definition'])) {
+                return $parameterLevelSchema['definition'];
+            }
+
             $mergedSchema = $this->mergeSchemas($mergedSchema, $parameterLevelSchema);
         }
 

--- a/tests/Fixtures/Utils/SchemaGeneratorFixture.php
+++ b/tests/Fixtures/Utils/SchemaGeneratorFixture.php
@@ -397,4 +397,17 @@ class SchemaGeneratorFixture
         $inferredParam
     ): void {
     }
+
+    /**
+     * Parameter with complete custom definition via #[Schema(definition: ...)]
+     */
+    public function parameterWithRawDefinition(
+        #[Schema(definition: [
+            'description' => 'Custom-defined schema',
+            'type' => 'string',
+            'format' => 'uuid'
+        ])]
+        string $custom
+    ): void {
+    }
 }

--- a/tests/Integration/SchemaGenerationTest.php
+++ b/tests/Integration/SchemaGenerationTest.php
@@ -354,3 +354,16 @@ it('infers parameter type as "any" (omits type) if only constraints are given in
 
     expect($schema['required'])->toEqual(['inferredParam']);
 });
+
+it('uses raw parameter-level schema definition as-is', function () {
+    $method = new ReflectionMethod(SchemaGeneratorFixture::class, 'parameterWithRawDefinition');
+    $schema = $this->schemaGenerator->generate($method);
+
+    expect($schema['properties']['custom'])->toEqual([
+        'description' => 'Custom-defined schema',
+        'type' => 'string',
+        'format' => 'uuid'
+    ]);
+
+    expect($schema['required'])->toEqual(['custom']);
+});


### PR DESCRIPTION
This PR fixes [issue #55](https://github.com/php-mcp/server/issues/55), where parameter-level `#[Schema(...)]` attributes incorrectly wrapped the `definition` inside a `'definition'` key