### PR TITLE
Allow custom annotations for MCP elements

### DIFF
--- a/src/Attributes/McpPrompt.php
+++ b/src/Attributes/McpPrompt.php
@@ -9,7 +9,7 @@ use Attribute;
  * The method should return the prompt messages, potentially using arguments for templating.
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
-final class McpPrompt
+class McpPrompt
 {
     /**
      * @param  ?string  $name  Overrides the prompt name (defaults to method name).

--- a/src/Attributes/McpResource.php
+++ b/src/Attributes/McpResource.php
@@ -10,7 +10,7 @@ use PhpMcp\Schema\Annotations;
  * Used primarily for the 'resources/list' discovery.
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
-final class McpResource
+class McpResource
 {
     /**
      * @param  string  $uri  The specific URI identifying this resource instance. Must be unique within the server.

--- a/src/Attributes/McpResourceTemplate.php
+++ b/src/Attributes/McpResourceTemplate.php
@@ -10,7 +10,7 @@ use PhpMcp\Schema\Annotations;
  * This is informational, used for 'resources/templates/list'.
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
-final class McpResourceTemplate
+class McpResourceTemplate
 {
     /**
      * @param  string  $uriTemplate  The URI template string (RFC 6570).


### PR DESCRIPTION
I'd like to use custom annotations that extends the ones provided by php-mcp.

I've discovered that some of the annotations I'd like to inherit were final and that the provided Discoverer would not match subclasses of the annotations. I'm not sure if it's accidental or by design.

This change would allow me to use the default Discoverer with custom annotations instead of making my own.