### PR TITLE
feat: Add PSR-7 middleware support for HTTP transports

### DIFF
--- a/tests/Fixtures/General/RequestAttributeChecker.php
+++ b/tests/Fixtures/General/RequestAttributeChecker.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\General;
+
+use PhpMcp\Schema\Content\TextContent;
+use PhpMcp\Server\Context;
+
+class RequestAttributeChecker
+{
+    public function checkAttribute(Context $context): TextContent
+    {
+        $attribute = $context->request->getAttribute('middleware-attr');
+        if ($attribute === 'middleware-value') {
+            return TextContent::make('middleware-value-found: ' . $attribute);
+        }
+
+        return TextContent::make('middleware-value-not-found: ' . $attribute);
+    }
+}

--- a/tests/Fixtures/Middlewares/ErrorMiddleware.php
+++ b/tests/Fixtures/Middlewares/ErrorMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class ErrorMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        if (str_contains($request->getUri()->getPath(), '/error-middleware')) {
+            throw new \Exception('Middleware error');
+        }
+        return $next($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/FirstMiddleware.php
+++ b/tests/Fixtures/Middlewares/FirstMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+class FirstMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        $result = $next($request);
+
+        return match (true) {
+            $result instanceof PromiseInterface => $result->then(fn($response) => $this->handle($response)),
+            $result instanceof ResponseInterface => $this->handle($result),
+            default => $result
+        };
+    }
+
+    private function handle($response)
+    {
+        if ($response instanceof ResponseInterface) {
+            $existing = $response->getHeaderLine('X-Middleware-Order');
+            $new = $existing ? $existing . ',first' : 'first';
+            return $response->withHeader('X-Middleware-Order', $new);
+        }
+        return $response;
+    }
+}

--- a/tests/Fixtures/Middlewares/HeaderMiddleware.php
+++ b/tests/Fixtures/Middlewares/HeaderMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+class HeaderMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        $result = $next($request);
+
+        return match (true) {
+            $result instanceof PromiseInterface => $result->then(fn($response) => $this->handle($response)),
+            $result instanceof ResponseInterface => $this->handle($result),
+            default => $result
+        };
+    }
+
+    private function handle($response)
+    {
+        return $response instanceof ResponseInterface
+            ? $response->withHeader('X-Test-Middleware', 'header-added')
+            : $response;
+    }
+}

--- a/tests/Fixtures/Middlewares/RequestAttributeMiddleware.php
+++ b/tests/Fixtures/Middlewares/RequestAttributeMiddleware.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class RequestAttributeMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        $request = $request->withAttribute('middleware-attr', 'middleware-value');
+        return $next($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/SecondMiddleware.php
+++ b/tests/Fixtures/Middlewares/SecondMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+class SecondMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        $result = $next($request);
+
+        return match (true) {
+            $result instanceof PromiseInterface => $result->then(fn($response) => $this->handle($response)),
+            $result instanceof ResponseInterface => $this->handle($result),
+            default => $result
+        };
+    }
+
+    private function handle($response)
+    {
+        if ($response instanceof ResponseInterface) {
+            $existing = $response->getHeaderLine('X-Middleware-Order');
+            $new = $existing ? $existing . ',second' : 'second';
+            return $response->withHeader('X-Middleware-Order', $new);
+        }
+        return $response;
+    }
+}

--- a/tests/Fixtures/Middlewares/ShortCircuitMiddleware.php
+++ b/tests/Fixtures/Middlewares/ShortCircuitMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+use React\Http\Message\Response;
+
+class ShortCircuitMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        if (str_contains($request->getUri()->getPath(), '/short-circuit')) {
+            return new Response(418, [], 'Short-circuited by middleware');
+        }
+        return $next($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/ThirdMiddleware.php
+++ b/tests/Fixtures/Middlewares/ThirdMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMcp\Server\Tests\Fixtures\Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+class ThirdMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, callable $next)
+    {
+        $result = $next($request);
+
+        return match (true) {
+            $result instanceof PromiseInterface => $result->then(fn($response) => $this->handle($response)),
+            $result instanceof ResponseInterface => $this->handle($result),
+            default => $result
+        };
+    }
+
+    private function handle($response)
+    {
+        if ($response instanceof ResponseInterface) {
+            $existing = $response->getHeaderLine('X-Middleware-Order');
+            $new = $existing ? $existing . ',third' : 'third';
+            return $response->withHeader('X-Middleware-Order', $new);
+        }
+        return $response;
+    }
+}

--- a/tests/Fixtures/ServerScripts/HttpTestServer.php
+++ b/tests/Fixtures/ServerScripts/HttpTestServer.php
@@ -10,6 +10,14 @@ use PhpMcp\Server\Transports\HttpServerTransport;
 use PhpMcp\Server\Tests\Fixtures\General\ToolHandlerFixture;
 use PhpMcp\Server\Tests\Fixtures\General\ResourceHandlerFixture;
 use PhpMcp\Server\Tests\Fixtures\General\PromptHandlerFixture;
+use PhpMcp\Server\Tests\Fixtures\General\RequestAttributeChecker;
+use PhpMcp\Server\Tests\Fixtures\Middlewares\HeaderMiddleware;
+use PhpMcp\Server\Tests\Fixtures\Middlewares\RequestAttributeMiddleware;
+use PhpMcp\Server\Tests\Fixtures\Middlewares\ShortCircuitMiddleware;
+use PhpMcp\Server\Tests\Fixtures\Middlewares\FirstMiddleware;
+use PhpMcp\Server\Tests\Fixtures\Middlewares\SecondMiddleware;
+use PhpMcp\Server\Tests\Fixtures\Middlewares\ThirdMiddleware;
+use PhpMcp\Server\Tests\Fixtures\Middlewares\ErrorMiddleware;
 use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
 
@@ -32,11 +40,22 @@ try {
         ->withServerInfo('HttpIntegrationTestServer', '0.1.0')
         ->withLogger($logger)
         ->withTool([ToolHandlerFixture::class, 'greet'], 'greet_http_tool')
+        ->withTool([RequestAttributeChecker::class, 'checkAttribute'], 'check_request_attribute_tool')
         ->withResource([ResourceHandlerFixture::class, 'getStaticText'], "test://http/static", 'static_http_resource')
         ->withPrompt([PromptHandlerFixture::class, 'generateSimpleGreeting'], 'simple_http_prompt')
         ->build();
 
-    $transport = new HttpServerTransport($host, $port, $mcpPathPrefix);
+    $middlewares = [
+        new HeaderMiddleware(),
+        new RequestAttributeMiddleware(),
+        new ShortCircuitMiddleware(),
+        new FirstMiddleware(),
+        new SecondMiddleware(),
+        new ThirdMiddleware(),
+        new ErrorMiddleware()
+    ];
+
+    $transport = new HttpServerTransport($host, $port, $mcpPathPrefix, null, $middlewares);
     $server->listen($transport);
 
     exit(0);

--- a/tests/Mocks/Clients/MockJsonHttpClient.php
+++ b/tests/Mocks/Clients/MockJsonHttpClient.php
@@ -13,6 +13,7 @@ class MockJsonHttpClient
     public Browser $browser;
     public string $baseUrl;
     public ?string $sessionId = null;
+    public array $lastResponseHeaders = []; // Store last response headers for testing
 
     public function __construct(string $host, int $port, string $mcpPath, int $timeout = 2)
     {
@@ -37,6 +38,14 @@ class MockJsonHttpClient
 
         return $this->browser->post($this->baseUrl, $headers, $body)
             ->then(function (ResponseInterface $response) use ($method) {
+                // Store response headers for testing
+                $this->lastResponseHeaders = [];
+                foreach ($response->getHeaders() as $name => $values) {
+                    foreach ($values as $value) {
+                        $this->lastResponseHeaders[] = "{$name}: {$value}";
+                    }
+                }
+
                 $bodyContent = (string) $response->getBody()->getContents();
                 $statusCode = $response->getStatusCode();
 

--- a/tests/Mocks/Clients/MockSseClient.php
+++ b/tests/Mocks/Clients/MockSseClient.php
@@ -22,6 +22,7 @@ class MockSseClient
     private array $receivedSseEvents = []; // Stores raw SSE events (type, data, id)
     public ?string $endpointUrl = null; // The /message endpoint URL provided by server
     public ?string $clientId = null; // The clientId from the /message endpoint URL
+    public ?ResponseInterface $lastConnectResponse = null; // Last connect response for header testing
 
     public function __construct(int $timeout = 2)
     {
@@ -32,6 +33,7 @@ class MockSseClient
     {
         return $this->browser->requestStreaming('GET', $sseBaseUrl)
             ->then(function (ResponseInterface $response) {
+                $this->lastConnectResponse = $response; // Store response for header testing
                 if ($response->getStatusCode() !== 200) {
                     $body = (string) $response->getBody();
                     throw new \RuntimeException("SSE connection failed with status {$response->getStatusCode()}: {$body}");


### PR DESCRIPTION
Adds PSR-7 compatible middleware support to both `HttpServerTransport` and `StreamableHttpServerTransport`.