### PR TITLE
Fix: Widen symfony/finder dependency to resolve conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "react/http": "^1.11",
         "react/promise": "^3.0",
         "react/stream": "^1.4",
-        "symfony/finder": "^6.4 || ^7.2"
+        "symfony/finder": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.75",


### PR DESCRIPTION
The previous constraint `^6.4 || ^7.2` for `symfony/finder` was too restrictive and caused dependency conflicts in projects that use other libraries requiring older versions of `symfony/finder`, such as `friendsofsymfony/rest-bundle`.

The usage of `symfony/finder` in this project is basic and compatible with older versions. This commit widens the allowed version range to `^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0`, ensuring better compatibility with a wider range of projects.