### PR TITLE
fix: use docblock description instead of summary

### DIFF
--- a/src/ServerBuilder.php
+++ b/src/ServerBuilder.php
@@ -323,7 +323,7 @@ final class ServerBuilder
                     $docBlock = $docBlockParser->parseDocBlock($reflection->getDocComment() ?? null);
 
                     $name = $data['name'] ?? ($methodName === '__invoke' ? $classShortName : $methodName);
-                    $description = $data['description'] ?? $docBlockParser->getSummary($docBlock) ?? null;
+                    $description = $data['description'] ?? $docBlockParser->getDescription($docBlock) ?? null;
                 }
 
                 $inputSchema = $data['inputSchema'] ?? $schemaGenerator->generate($reflection);


### PR DESCRIPTION
The summary is only the first line of the docblock. In many cases you need more than a single line to describe your tool adequately to the LLM. Using the description will return the first line plus all other lines until the parameter definitions.

Alternatively we could make manual tools support the `#[McpTool(...)]` annotation?