### PR TITLE
fix: Preserve defaults and avoid type conflicts for polymorphic schemas

### DIFF
--- a/tests/Fixtures/Utils/SchemaGeneratorFixture.php
+++ b/tests/Fixtures/Utils/SchemaGeneratorFixture.php
@@ -410,4 +410,37 @@ class SchemaGeneratorFixture
         string $custom
     ): void {
     }
+
+    /**
+     * Parameter with anyOf in definition; default comes from PHP signature.
+     * This tests the fix for schema merge conflicts where inferred "type": "array"
+     * from PHP type hint would conflict with anyOf allowing object notation.
+     */
+    public function parameterWithAnyOfDefinition(
+        #[Schema(definition: [
+            'anyOf' => [
+                ['type' => 'object', 'additionalProperties' => true],
+                ['type' => 'array', 'items' => ['type' => 'object']]
+            ],
+            'description' => 'Properties as {"key":"value"} object or array format',
+        ])]
+        array|stdClass $properties = []
+    ): void {
+    }
+
+    /**
+     * Method-level schema with anyOf property and array type hint to ensure inferred type is dropped.
+     */
+    #[Schema(properties: [
+        'payload' => [
+            'anyOf' => [
+                ['type' => 'object', 'additionalProperties' => true],
+                ['type' => 'array', 'items' => ['type' => 'object']]
+            ],
+            'description' => 'Payload as object or array of objects'
+        ]
+    ])]
+    public function methodLevelAnyOfProperty(array $payload): void
+    {
+    }
 }


### PR DESCRIPTION
Fixes parameter-level Schema attribute handling to support both object and array notation for properties parameters.

Resolves two related schema generation issues:

1. Parameter-level Schema attributes with 'definition' key now preserve PHP signature defaults when the definition omits one. Previously defaults were lost when using full definition overrides.

2. Schema merging removes inferred type constraints when anyOf/oneOf/allOf is present WITHOUT an explicit type in the dominant schema. This prevents conflicts where inferred "type": "array" from PHP type hints conflicts with anyOf allowing object notation, while respecting explicit type declarations.

Includes test fixtures and integration coverage for parameter- and method-level anyOf schemas.

P.S.: `composer lint` was NOT run, as it reformats a bunch of files on my system...